### PR TITLE
Prepare Gravlax 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file records user-visible changes in each Gravlax release.
 
 ## Unreleased
 
+## [0.2.1] - 2026-09-07
+
 - Make rooted collection sources and parent layers relocatable through an optional
   `--locations` manifest keyed by committed content identities. Existing archive and
   collection formats, index bytes and roots remain unchanged; relocation adds no
@@ -17,6 +19,8 @@ This file records user-visible changes in each Gravlax release.
   their relocation remains supported but cannot provide the rooted fast path.
 - Test moved layered bundles, unchanged archive/index hashes and I/O, cross-file
   replacement, malformed mappings, wrong roots, legacy identity and corruption.
+- Normalize canonical path aliases in relocation acceptance tests on macOS and
+  Windows while preserving content, query-result and I/O comparisons.
 
 ## [0.2.0] - 2026-09-05
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,7 +361,7 @@ dependencies = [
 
 [[package]]
 name = "eval"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "gravlax-evidence-io",
@@ -459,7 +459,7 @@ dependencies = [
 
 [[package]]
 name = "gravlax"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "gravlax-anno"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "gravlax-evidence-io"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "gravlax-ingest"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "gravlax-evidence-io",
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "gravlax-output"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "libc",
  "serde",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "replay"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "gravlax-evidence-io",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 rust-version = "1.89"
 authors = ["Gravlax contributors"]
@@ -41,10 +41,10 @@ noodles-sam = "0.90"
 noodles-bgzf = "0.51"
 noodles-core = "0.20"
 noodles-gtf = "0.57"
-evidence-io = { package = "gravlax-evidence-io", version = "=0.2.0", path = "crates/evidence-io" }
-anno = { package = "gravlax-anno", version = "=0.2.0", path = "crates/anno" }
-ingest = { package = "gravlax-ingest", version = "=0.2.0", path = "crates/ingest" }
-gravlax-output = { version = "=0.2.0", path = "crates/gravlax-output" }
+evidence-io = { package = "gravlax-evidence-io", version = "=0.2.1", path = "crates/evidence-io" }
+anno = { package = "gravlax-anno", version = "=0.2.1", path = "crates/anno" }
+ingest = { package = "gravlax-ingest", version = "=0.2.1", path = "crates/ingest" }
+gravlax-output = { version = "=0.2.1", path = "crates/gravlax-output" }
 
 # cargo-dist owns the native archives and installers. Release-specific checks,
 # Python artifacts, the vendored source archive, and crates.io publication are

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gravlax-docs",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gravlax-docs",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@astrojs/starlight": "0.41.11",
         "astro": "7.2.10",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gravlax-docs",
   "type": "module",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "scripts": {
     "dev": "astro dev",

--- a/packaging/conda/local/meta.yaml
+++ b/packaging/conda/local/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = environ.get("GRAVLAX_VERSION", "0.2.0") %}
+{% set version = environ.get("GRAVLAX_VERSION", "0.2.1") %}
 
 package:
   name: gravlax

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gravlax-client"
-version = "0.2.0"
+version = "0.2.1"
 description = "Dependency-light Python client for the Gravlax aie command-line interface"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/python/src/gravlax/__init__.py
+++ b/python/src/gravlax/__init__.py
@@ -158,4 +158,4 @@ __all__ = [
     "read_mex",
 ]
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"


### PR DESCRIPTION
## Summary
- Synchronize all Rust workspace packages and exact internal dependency requirements, Python package/runtime, docs manifest/lockfile, and local Conda fallback to 0.2.1.
- Date the 0.2.1 changelog for the merged relocatable collection implementation and its platform acceptance fix.
- Preserve third-party dependency versions, historical benchmarks, and all archive/collection formats.

## Validation
- Release helper package dry-runs, version/package graph, and public-source history checks pass.
- Full all-feature Rust workspace tests pass.
- All 43 packaging tests and 91 Python tests pass.
- Documentation build and executable GQ/relocation acceptance pass; executable reports 0.2.1.

## Publication
This PR only prepares the coordinated version bump. No release tag or registry publication has been created. After merge, use the documented release helper from clean main to prepare and push v0.2.1.