### PR TITLE
Prepare 0.2.2: GeneFull replay, stranded EM, and assignment statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file records user-visible changes in each Gravlax release.
 
 ## Unreleased
 
+## [0.3.0] - 2026-09-10
+
 - Add forward, reverse and unstranded assignment to recovery EM, and extend
   STAR-style EM to GeneFull with the same model/strand for unique and ambiguous
   evidence. Record model, strand and counting units in emitted metadata.
@@ -13,8 +15,6 @@ This file records user-visible changes in each Gravlax release.
   expose `--support-memory-mib` and report storage scope and capacity.
 - Query GeneFull directly from aligned blocks using separate strand indexes.
   Preserve archive and compiled-annotation encodings and default Gene results.
-
-## [0.3.0] - 2026-09-10
 
 - Add `dev em --gene-full` for intron-inclusive recovery evaluation and pooled
   emission, with explicit masked-class coverage and counting-model metadata.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ This file records user-visible changes in each Gravlax release.
 
 ## Unreleased
 
+## [0.3.0] - 2026-09-10
+
+- Add `replay-rows --gene-full` for intron-inclusive, strand-aware gene-span
+  assignment from aligned blocks, with the existing global UMI collapse.
+  Support streaming/eager archives, BAM input, and compiled annotations.
+- Add Python `Client.replay(..., gene_full=True)` and record the counting model
+  in replay reports and MEX provenance. Reject incompatible velocity/audit flags.
+- Correct `assigned_molecules`, which previously counted representative rows.
+  Report molecule records, representatives, and UMI classes with separate
+  assignment numerators and denominators; all totals cover the full input.
+- Validate against an exhaustive overlap oracle, synthetic STARsolo runs,
+  equivalent representations, and matched brain-nucleus matrices. Preserve
+  default Gene matrices and archive/annotation encodings.
+
+
 ## [0.2.1] - 2026-09-07
 
 - Make rooted collection sources and parent layers relocatable through an optional

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,33 +4,73 @@ This file records user-visible changes in each Gravlax release.
 
 ## Unreleased
 
-## [0.3.0] - 2026-09-10
+## [0.2.2] - 2026-09-10
 
-- Add forward, reverse and unstranded assignment to recovery EM, and extend
-  STAR-style EM to GeneFull with the same model/strand for unique and ambiguous
-  evidence. Record model, strand and counting units in emitted metadata.
-- Add independent `dev em --eval-barcodes` and `--modes` selection, preserving
-  full-input prior fitting and the existing default models.
-- Spill packed EM supports according to their actual retained candidate volume;
-  expose `--support-memory-mib` and report storage scope and capacity.
-- Query GeneFull directly from aligned blocks using separate strand indexes.
-  Preserve archive and compiled-annotation encodings and default Gene results.
+### Compatibility and assignment statistics
 
-- Add `dev em --gene-full` for intron-inclusive recovery evaluation and pooled
-  emission, with explicit masked-class coverage and counting-model metadata.
-  Validate matched fixed-nucleus EM, annotation contrasts, and extension controls.
+Existing `.aie` archives, including legacy v1 archives, and compiled `.aic`
+annotations remain usable without re-ingestion or migration. Archive and
+annotation encodings and default Gene count matrices are unchanged.
+
+**Reporting change:** `replay-rows` reports now define `assigned_molecules` as
+molecule records with at least one uniquely assigned representative. Previously
+this field counted assigned representative rows, so its value can decrease even
+when the emitted count matrix is identical. It now aliases
+`assignment_statistics.assigned_molecule_records`; use
+`assignment_statistics.molecule_records` as its denominator. Consumers needing
+the previous row count must use `assignment_statistics.assigned_representative_rows`,
+with `assignment_statistics.representative_rows` as the denominator.
+
+Assignment statistics separately report molecule records, representative rows
+and raw UMI classes across the full consumed input, including barcodes outside
+the called-nucleus set. These are not collapsed-UMI counts. `counted_umis` reports
+the full-input post-collapse total; use the emitted matrix sum for a selected
+barcode population. This reporting correction also applies to default Gene
+replay; archive compatibility does not imply unchanged report-field semantics.
+
+### GeneFull replay and EM
+
 - Add `replay-rows --gene-full` for intron-inclusive, strand-aware gene-span
   assignment from aligned blocks, with the existing global UMI collapse.
   Support streaming/eager archives, BAM input, and compiled annotations.
-- Add Python `Client.replay(..., gene_full=True)` and record the counting model
-  in replay reports and MEX provenance. Reject incompatible velocity/audit flags.
-- Correct `assigned_molecules`, which previously counted representative rows.
-  Report molecule records, representatives, and UMI classes with separate
-  assignment numerators and denominators; all totals cover the full input.
-- Validate against an exhaustive overlap oracle, synthetic STARsolo runs,
-  equivalent representations, and matched brain-nucleus matrices. Preserve
-  default Gene matrices and archive/annotation encodings.
+  Skipped alignment gaps alone do not assign a gene.
+- Add Python `Client.replay(..., gene_full=True, solo_strand=...)` and record
+  the counting model in replay reports and MEX provenance. Reject incompatible
+  velocity/audit flags.
+- Add `dev em --gene-full` for recovery evaluation and pooled emission, with
+  explicit masked-class coverage and counting-model metadata. Accuracy is
+  conditional on evaluable raw UMI classes before one-mismatch collapse.
+- Add `dev em --solo-strand forward|reverse|unstranded` to recovery EM and its
+  eager reference, and support `--star --gene-full` under all three strand
+  policies. Apply the same model and strand to unique and ambiguous evidence;
+  record them and the output counting units in metadata. Gene/forward remains
+  the command default.
 
+### Execution controls and validation
+
+- Add independent `dev em --eval-barcodes` and `--modes` selection, preserving
+  full-input prior fitting and the existing default models. Selecting fewer
+  models reduces work without changing retained models' results.
+- Spill packed EM supports according to actual retained candidate volume;
+  expose `--support-memory-mib` (512 MiB by default; zero forces spilling) and
+  report storage scope and capacity. This budget is not a whole-process memory
+  cap and does not establish a reduction in peak process memory.
+- Query GeneFull directly from aligned blocks using separate strand indexes.
+  Isolated forward/reverse lookups were approximately 1.77 times faster; whole
+  replay and EM timings do not establish a comparable end-to-end speedup.
+- Validate against an exhaustive overlap oracle, synthetic STARsolo comparisons
+  for both counting models and all strands, streaming/eager and forced-spill
+  equivalence, and matched brain-nucleus matrices and EM. Fixed-nucleus EM keeps
+  the original 6,460 nuclei and preserves the manuscript's shared metrics;
+  nucleus calling is assessed separately from this fixed-population comparison.
+  Default Gene replay matrices and EM results are preserved. The existing Gene
+  UMI tie-breaking difference from STARsolo remains; synthetic EM agreement is
+  not a claim of universal STARsolo equivalence.
+
+See [GeneFull replay validation](docs/genefull-validation.md),
+[EM validation](docs/genefull-em-validation.md), and
+[strand and optimization validation](docs/genefull-em-strands-optimization.md)
+for counting units, denominators, biological comparisons and measured tradeoffs.
 
 ## [0.2.1] - 2026-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ This file records user-visible changes in each Gravlax release.
 
 ## Unreleased
 
+- Add forward, reverse and unstranded assignment to recovery EM, and extend
+  STAR-style EM to GeneFull with the same model/strand for unique and ambiguous
+  evidence. Record model, strand and counting units in emitted metadata.
+- Add independent `dev em --eval-barcodes` and `--modes` selection, preserving
+  full-input prior fitting and the existing default models.
+- Spill packed EM supports according to their actual retained candidate volume;
+  expose `--support-memory-mib` and report storage scope and capacity.
+- Query GeneFull directly from aligned blocks using separate strand indexes.
+  Preserve archive and compiled-annotation encodings and default Gene results.
+
 ## [0.3.0] - 2026-09-10
 
 - Add `dev em --gene-full` for intron-inclusive recovery evaluation and pooled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This file records user-visible changes in each Gravlax release.
 
 ## [0.3.0] - 2026-09-10
 
+- Add `dev em --gene-full` for intron-inclusive recovery evaluation and pooled
+  emission, with explicit masked-class coverage and counting-model metadata.
+  Validate matched fixed-nucleus EM, annotation contrasts, and extension controls.
 - Add `replay-rows --gene-full` for intron-inclusive, strand-aware gene-span
   assignment from aligned blocks, with the existing global UMI collapse.
   Support streaming/eager archives, BAM input, and compiled annotations.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,7 +361,7 @@ dependencies = [
 
 [[package]]
 name = "eval"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "gravlax-evidence-io",
@@ -459,7 +459,7 @@ dependencies = [
 
 [[package]]
 name = "gravlax"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "gravlax-anno"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "gravlax-evidence-io"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "gravlax-ingest"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "gravlax-evidence-io",
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "gravlax-output"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "libc",
  "serde",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "replay"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "gravlax-evidence-io",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,7 +361,7 @@ dependencies = [
 
 [[package]]
 name = "eval"
-version = "0.3.0"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "gravlax-evidence-io",
@@ -459,7 +459,7 @@ dependencies = [
 
 [[package]]
 name = "gravlax"
-version = "0.3.0"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "blake3",
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "gravlax-anno"
-version = "0.3.0"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "blake3",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "gravlax-evidence-io"
-version = "0.3.0"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "blake3",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "gravlax-ingest"
-version = "0.3.0"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "gravlax-evidence-io",
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "gravlax-output"
-version = "0.3.0"
+version = "0.2.2"
 dependencies = [
  "libc",
  "serde",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "replay"
-version = "0.3.0"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "gravlax-evidence-io",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.89"
 authors = ["Gravlax contributors"]
@@ -41,10 +41,10 @@ noodles-sam = "0.90"
 noodles-bgzf = "0.51"
 noodles-core = "0.20"
 noodles-gtf = "0.57"
-evidence-io = { package = "gravlax-evidence-io", version = "=0.2.1", path = "crates/evidence-io" }
-anno = { package = "gravlax-anno", version = "=0.2.1", path = "crates/anno" }
-ingest = { package = "gravlax-ingest", version = "=0.2.1", path = "crates/ingest" }
-gravlax-output = { version = "=0.2.1", path = "crates/gravlax-output" }
+evidence-io = { package = "gravlax-evidence-io", version = "=0.3.0", path = "crates/evidence-io" }
+anno = { package = "gravlax-anno", version = "=0.3.0", path = "crates/anno" }
+ingest = { package = "gravlax-ingest", version = "=0.3.0", path = "crates/ingest" }
+gravlax-output = { version = "=0.3.0", path = "crates/gravlax-output" }
 
 # cargo-dist owns the native archives and installers. Release-specific checks,
 # Python artifacts, the vendored source archive, and crates.io publication are

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.2.2"
 edition = "2021"
 rust-version = "1.89"
 authors = ["Gravlax contributors"]
@@ -41,10 +41,10 @@ noodles-sam = "0.90"
 noodles-bgzf = "0.51"
 noodles-core = "0.20"
 noodles-gtf = "0.57"
-evidence-io = { package = "gravlax-evidence-io", version = "=0.3.0", path = "crates/evidence-io" }
-anno = { package = "gravlax-anno", version = "=0.3.0", path = "crates/anno" }
-ingest = { package = "gravlax-ingest", version = "=0.3.0", path = "crates/ingest" }
-gravlax-output = { version = "=0.3.0", path = "crates/gravlax-output" }
+evidence-io = { package = "gravlax-evidence-io", version = "=0.2.2", path = "crates/evidence-io" }
+anno = { package = "gravlax-anno", version = "=0.2.2", path = "crates/anno" }
+ingest = { package = "gravlax-ingest", version = "=0.2.2", path = "crates/ingest" }
+gravlax-output = { version = "=0.2.2", path = "crates/gravlax-output" }
 
 # cargo-dist owns the native archives and installers. Release-specific checks,
 # Python artifacts, the vendored source archive, and crates.io publication are

--- a/crates/aie/src/archivecmd.rs
+++ b/crates/aie/src/archivecmd.rs
@@ -7,8 +7,8 @@ pub(crate) mod transcriptec;
 
 use crate::rows::{
     extract_rows, extract_rows_for_archive, extract_rows_with_identity, identity_of_consumed_file,
-    replay_rows_stranded, ConsumedFileIdentity, Extracted, ExtractedTerminalTails, MolChain,
-    MolRec, PatAlt, ReplayRowsAccumulator, SAME_SHAPE,
+    AssignmentStats, ConsumedFileIdentity, Extracted, ExtractedTerminalTails, MolChain, MolRec,
+    PatAlt, ReplayRowsAccumulator, SAME_SHAPE,
 };
 use anyhow::{bail, Context, Result};
 use clap::{Parser, ValueEnum};
@@ -201,6 +201,10 @@ pub struct ReplayRowsArgs {
     /// Emit STARsolo Velocyto semantics (spliced/unspliced/ambiguous matrices) instead of Gene.
     #[arg(long)]
     pub velocity: bool,
+    /// Count aligned-block overlaps with full gene spans (exons and introns), matching
+    /// STARsolo GeneFull. Gene remains the default.
+    #[arg(long, conflicts_with_all = ["velocity", "audit_multigene"])]
+    pub gene_full: bool,
     /// STARsolo cDNA-alignment/transcript strand relationship. 10x 3' uses forward; R2-only 10x
     /// 5' uses reverse.
     #[arg(long, value_enum, default_value_t = SoloStrandArg::Forward)]
@@ -2152,7 +2156,7 @@ struct StreamingReplayArchive {
     n_mols: usize,
 }
 
-type StreamingReplayResult = (FxHashMap<(u32, u32), u32>, u64, u64);
+type StreamingReplayResult = (FxHashMap<(u32, u32), u32>, AssignmentStats, u64);
 
 impl StreamingReplayArchive {
     fn open(path: &Path) -> Result<Self> {
@@ -2196,8 +2200,9 @@ impl StreamingReplayArchive {
         &self,
         anno: &anno::Annotation,
         solo_strand: anno::assign::SoloStrand,
+        gene_full: bool,
     ) -> Result<StreamingReplayResult> {
-        let mut replay = ReplayRowsAccumulator::with_strand(&self.x, anno, solo_strand);
+        let mut replay = ReplayRowsAccumulator::with_model(&self.x, anno, solo_strand, gene_full);
         replay.reserve_assignments(self.n_mols);
         // Two access units per worker smooth decode density and amortize reducer barriers while
         // retaining bounded memory use in complete-command peak-RSS measurements.
@@ -2224,7 +2229,7 @@ impl StreamingReplayArchive {
                 self.n_mols
             );
         }
-        Ok(replay.finish())
+        Ok(replay.finish_with_stats())
     }
     /// Decode the archive in the same bounded batches as streaming Gene replay, but reduce each
     /// batch immediately to packed (class,gene,evidence-kind) support words.  The final EM owns
@@ -3779,7 +3784,8 @@ pub fn run_replay_rows(args: ReplayRowsArgs) -> Result<()> {
         let t_open = t0.elapsed().as_secs_f32();
         let (anno, annotation_identity) = load_replay_annotation(&args.gtf, reporting)?;
         let t_anno = t0.elapsed().as_secs_f32();
-        let (counts, n_assigned, total) = archive.replay(&anno, solo_strand)?;
+        let (counts, assignment_stats, total) =
+            archive.replay(&anno, solo_strand, args.gene_full)?;
         let t_replay = t0.elapsed().as_secs_f32();
         let artifact = emit_matrix(
             &counts,
@@ -3817,7 +3823,8 @@ pub fn run_replay_rows(args: ReplayRowsArgs) -> Result<()> {
                 velocity: false,
                 multigene_audit: false,
                 molecules: archive.n_mols as u64,
-                assigned_molecules: Some(n_assigned),
+                assigned_molecules: Some(assignment_stats.assigned_molecule_records),
+                assignment_statistics: Some(assignment_stats),
                 counted_umis: Some(total),
                 matrix_entries: Some(counts.len() as u64),
                 audit: None,
@@ -3826,8 +3833,8 @@ pub fn run_replay_rows(args: ReplayRowsArgs) -> Result<()> {
             emit_replay_report(&args, &summary, &context, metadata_path.as_deref())?;
         }
         eprintln!(
-            "molecules {} -> assigned {} -> {} UMIs in {} entries | streaming | open+dict {t_open:.1}s, +anno {:.1}s, +decode/replay {:.1}s, total {:.1}s",
-            archive.n_mols, n_assigned, total, counts.len(), t_anno - t_open,
+            "molecule records {} -> records with assignment {}; representative rows {} assigned / {} total; UMI classes {} assigned / {} total -> {} collapsed UMIs in {} entries (all input; not restricted to called nuclei) | streaming | open+dict {t_open:.1}s, +anno {:.1}s, +decode/replay {:.1}s, total {:.1}s",
+            archive.n_mols, assignment_stats.assigned_molecule_records, assignment_stats.assigned_representative_rows, assignment_stats.representative_rows, assignment_stats.assigned_umi_classes, assignment_stats.umi_classes, total, counts.len(), t_anno - t_open,
             t_replay - t_anno, t0.elapsed().as_secs_f32()
         );
         exit_without_teardown();
@@ -3925,6 +3932,7 @@ pub fn run_replay_rows(args: ReplayRowsArgs) -> Result<()> {
             multigene_audit: true,
             molecules: x.mols.len() as u64,
             assigned_molecules: None,
+            assignment_statistics: None,
             counted_umis: None,
             matrix_entries: None,
             audit: Some(audit),
@@ -3988,6 +3996,7 @@ pub fn run_replay_rows(args: ReplayRowsArgs) -> Result<()> {
                 multigene_audit: false,
                 molecules: x.mols.len() as u64,
                 assigned_molecules: None,
+                assignment_statistics: None,
                 counted_umis: Some(n_counted),
                 matrix_entries: Some(vc.len() as u64),
                 audit: None,
@@ -4001,7 +4010,8 @@ pub fn run_replay_rows(args: ReplayRowsArgs) -> Result<()> {
         );
         return Ok(());
     }
-    let (counts, n_assigned, total) = replay_rows_stranded(&x, &anno, solo_strand);
+    let (counts, assignment_stats, total) =
+        crate::rows::replay_rows_model(&x, &anno, solo_strand, args.gene_full);
     let t_replay = t0.elapsed().as_secs_f32();
     let artifact = emit_matrix(
         &counts,
@@ -4055,7 +4065,8 @@ pub fn run_replay_rows(args: ReplayRowsArgs) -> Result<()> {
             velocity: false,
             multigene_audit: false,
             molecules: x.mols.len() as u64,
-            assigned_molecules: Some(n_assigned),
+            assigned_molecules: Some(assignment_stats.assigned_molecule_records),
+            assignment_statistics: Some(assignment_stats),
             counted_umis: Some(total),
             matrix_entries: Some(counts.len() as u64),
             audit: None,
@@ -4064,8 +4075,8 @@ pub fn run_replay_rows(args: ReplayRowsArgs) -> Result<()> {
         emit_replay_report(&args, &summary, &context, metadata_path.as_deref())?;
     }
     eprintln!(
-        "molecules {} -> assigned {} -> {} UMIs in {} entries | eager | load {t_load:.1}s, +anno {:.1}s, +replay {:.1}s, total {:.1}s",
-        x.mols.len(), n_assigned, total, counts.len(),
+        "molecule records {} -> records with assignment {}; representative rows {} assigned / {} total; UMI classes {} assigned / {} total -> {} collapsed UMIs in {} entries (all input; not restricted to called nuclei) | eager | load {t_load:.1}s, +anno {:.1}s, +replay {:.1}s, total {:.1}s",
+        x.mols.len(), assignment_stats.assigned_molecule_records, assignment_stats.assigned_representative_rows, assignment_stats.representative_rows, assignment_stats.assigned_umi_classes, assignment_stats.umi_classes, total, counts.len(),
         t_anno - t_load, t_replay - t_anno, t0.elapsed().as_secs_f32()
     );
     exit_without_teardown();
@@ -4185,7 +4196,9 @@ struct ReplayReportSummary {
     velocity: bool,
     multigene_audit: bool,
     molecules: u64,
+    /// Records with at least one uniquely assigned representative (not rows).
     assigned_molecules: Option<u64>,
+    assignment_statistics: Option<AssignmentStats>,
     counted_umis: Option<u64>,
     matrix_entries: Option<u64>,
     audit: Option<crate::rows::MultigeneAuditSummary>,
@@ -4770,6 +4783,21 @@ fn replay_report_context(
         serde_json::json!(args.from_molecule_bam),
     );
     parameters.insert("velocity".into(), serde_json::json!(args.velocity));
+    parameters.insert("gene_full".into(), serde_json::json!(args.gene_full));
+    parameters.insert(
+        "assignment_statistics_scope".into(),
+        serde_json::json!("all input records; not restricted to called nuclei"),
+    );
+    parameters.insert(
+        "counting_model".into(),
+        serde_json::json!(if args.velocity {
+            "Velocyto"
+        } else if args.gene_full {
+            "GeneFull"
+        } else {
+            "Gene"
+        }),
+    );
     parameters.insert(
         "audit_multigene".into(),
         serde_json::json!(args.audit_multigene),

--- a/crates/aie/src/archivecmd.rs
+++ b/crates/aie/src/archivecmd.rs
@@ -2237,8 +2237,9 @@ impl StreamingReplayArchive {
     fn packed_em_accumulator(
         &self,
         anno: &anno::Annotation,
+        gene_full: bool,
     ) -> Result<crate::rows::PackedEmAccumulator> {
-        let mut em = crate::rows::PackedEmAccumulator::new(&self.x, anno, self.n_mols)?;
+        let mut em = crate::rows::PackedEmAccumulator::new(&self.x, anno, self.n_mols, gene_full)?;
         let threads = rayon::current_num_threads().max(1);
         // The disk-backed path exists to bound large-archive memory. Eight access units keep its
         // decoded MolRec window small; classification still subdivides them into 65k tasks and
@@ -2362,6 +2363,10 @@ pub struct EmArgs {
     pub archive: PathBuf,
     #[arg(long)]
     pub gtf: PathBuf,
+    /// Use intron-inclusive GeneFull candidates on the forward strand. Default: Gene.
+    /// The independent STAR-compatible EM implementation remains Gene-only.
+    #[arg(long, conflicts_with = "star")]
+    pub gene_full: bool,
     /// Fraction of mixed classes to mask for the labeled evaluation.
     #[arg(long, default_value_t = 0.2)]
     pub mask: f64,
@@ -2710,6 +2715,7 @@ pub fn run_em(args: EmArgs) -> Result<()> {
     let mut paired_metrics: Vec<crate::rows::PackedPairedMetrics> = Vec::new();
     let mut group_names: Vec<String> = Vec::new();
     let mut group_eval_cells = 0usize;
+    let mut evaluation_counts = serde_json::Value::Null;
     let (recovered, cells) = if args.eager {
         let x = read_archive(&args.archive)?;
         let recovered = crate::rows::em_experiment(
@@ -2719,11 +2725,12 @@ pub fn run_em(args: EmArgs) -> Result<()> {
             args.seed,
             args.alpha,
             args.plot.is_some().then_some(&mut cals),
+            args.gene_full,
         );
         (recovered, x.cells)
     } else {
         let mut archive = StreamingReplayArchive::open(&args.archive)?;
-        let em = archive.packed_em_accumulator(&anno)?;
+        let em = archive.packed_em_accumulator(&anno, args.gene_full)?;
         let cells = std::mem::take(&mut archive.x.cells);
         let cell_of_class = std::mem::take(&mut archive.cell_of_class);
         drop(archive);
@@ -2763,6 +2770,7 @@ pub fn run_em(args: EmArgs) -> Result<()> {
         } else {
             group_eval_cells = cells.len();
         }
+        evaluation_counts = packed.evaluation_counts(groups.as_ref());
         let recovered = packed.run(
             &anno,
             args.alpha,
@@ -2843,7 +2851,7 @@ pub fn run_em(args: EmArgs) -> Result<()> {
                 })
             })
             .collect();
-        let document = serde_json::json!({
+        let mut document = serde_json::json!({
             "schema_version": 2,
             "archive": args.archive,
             "gtf": args.gtf,
@@ -2885,6 +2893,10 @@ pub fn run_em(args: EmArgs) -> Result<()> {
             "modes": modes,
             "paired_comparisons": paired_comparisons,
         });
+        document["counting_model"] =
+            serde_json::json!(if args.gene_full { "GeneFull" } else { "Gene" });
+        document["strand_policy"] = serde_json::json!("forward");
+        document["evaluation_counts"] = evaluation_counts;
         std::fs::write(path, serde_json::to_vec_pretty(&document)?)
             .with_context(|| format!("write EM metrics {}", path.display()))?;
     }
@@ -2963,6 +2975,17 @@ pub fn run_em(args: EmArgs) -> Result<()> {
         }
         mtx.flush()?;
         feat.flush()?;
+        std::fs::write(
+            out_dir.join("metadata.json"),
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "counting_model": if args.gene_full { "GeneFull" } else { "Gene" },
+                "strand_policy": "forward",
+                "counting_unit": "fractional responsibility per UMI class before one-mismatch collapse",
+                "layer": "additive multi-only classes",
+                "archive": args.archive,
+                "annotation": args.gtf,
+            }))?,
+        )?;
         eprintln!(
             "wrote {} recovered entries to {}",
             triplets.len(),

--- a/crates/aie/src/archivecmd.rs
+++ b/crates/aie/src/archivecmd.rs
@@ -2238,14 +2238,23 @@ impl StreamingReplayArchive {
         &self,
         anno: &anno::Annotation,
         gene_full: bool,
+        solo_strand: anno::assign::SoloStrand,
+        support_memory_budget: usize,
     ) -> Result<crate::rows::PackedEmAccumulator> {
-        let mut em = crate::rows::PackedEmAccumulator::new(&self.x, anno, self.n_mols, gene_full)?;
+        let mut em = crate::rows::PackedEmAccumulator::new(
+            &self.x,
+            anno,
+            self.n_mols,
+            gene_full,
+            solo_strand,
+            support_memory_budget,
+        )?;
         let threads = rayon::current_num_threads().max(1);
-        // The disk-backed path exists to bound large-archive memory. Eight access units keep its
-        // decoded MolRec window small; classification still subdivides them into 65k tasks and
-        // can use the full Rayon pool. Small in-memory archives retain the faster, benchmarked
-        // two-per-thread decode window.
-        let batch_size = if em.spills_supports() {
+        // Record count is only a decode-window hint, not the support-spill decision. Eight
+        // access units keep large-input decoder scratch small; classification still subdivides
+        // them into 65k tasks and uses the Rayon pool. Actual support volume controls spilling.
+        // Small estimated inputs retain the two-per-thread decode window.
+        let batch_size = if em.small_decode_window() {
             threads.min(8)
         } else {
             threads * 2
@@ -2363,10 +2372,12 @@ pub struct EmArgs {
     pub archive: PathBuf,
     #[arg(long)]
     pub gtf: PathBuf,
-    /// Use intron-inclusive GeneFull candidates on the forward strand. Default: Gene.
-    /// The independent STAR-compatible EM implementation remains Gene-only.
-    #[arg(long, conflicts_with = "star")]
+    /// Use intron-inclusive GeneFull candidates. Default: Gene. Also applies to --star.
+    #[arg(long)]
     pub gene_full: bool,
+    /// cDNA-alignment/gene strand relationship, for both recovery and STAR-style EM.
+    #[arg(long, value_enum, default_value_t = SoloStrandArg::Forward)]
+    pub solo_strand: SoloStrandArg,
     /// Fraction of mixed classes to mask for the labeled evaluation.
     #[arg(long, default_value_t = 0.2)]
     pub mask: f64,
@@ -2379,6 +2390,18 @@ pub struct EmArgs {
     /// absent from the map retain the global fallback and are excluded from all mode scores.
     #[arg(long)]
     pub groups: Option<PathBuf>,
+    /// Score only these barcodes without changing the fitted priors or enabling group modes.
+    /// With --groups, overrides its scoring population while retaining the group assignments.
+    #[arg(long, conflicts_with_all = ["star", "eager"])]
+    pub eval_barcodes: Option<PathBuf>,
+    /// Comma-separated EM modes to run. Defaults to four base modes, or all nine with --groups.
+    /// Group-derived modes require --groups; emission requires pooled among the selected modes.
+    #[arg(long, value_delimiter = ',', value_parser = ["uniform", "cell", "pooled", "blend", "group", "hierarchical", "convex", "dirichlet-proxy", "depth-hybrid"],
+        conflicts_with_all = ["star", "eager", "convex_only", "dirichlet_only", "hybrid_only"])]
+    pub modes: Vec<String>,
+    /// Retained packed support budget in MiB; 0 forces disk spill. Does not cap total process RSS.
+    #[arg(long, default_value_t = 512, conflicts_with_all = ["star", "eager"])]
+    pub support_memory_mib: usize,
     /// Hierarchical pseudo-count mass borrowed from the supplied group distribution.
     #[arg(long, default_value_t = 20.0)]
     pub group_alpha: f64,
@@ -2447,7 +2470,7 @@ pub struct EmArgs {
     /// Barcode list defining emitted column order (for example, STARsolo raw barcodes.tsv).
     #[arg(long)]
     pub barcodes: Option<PathBuf>,
-    /// EM-0: replicate STARsolo --soloMultiMappers EM exactly (per-cell, intersection candidate
+    /// EM-0: use STARsolo --soloMultiMappers EM rules (per-cell, intersection candidate
     /// sets, STAR's init/zeroing/convergence) and emit UniqueAndMult-EM.mtx into --emit.
     #[arg(long)]
     pub star: bool,
@@ -2459,6 +2482,50 @@ pub struct EmArgs {
     /// the masked run's calibration counts.
     #[arg(long)]
     pub plot: Option<PathBuf>,
+}
+
+fn read_em_evaluation_barcodes(path: &PathBuf, cells: &[u32]) -> Result<Vec<bool>> {
+    let text = std::fs::read_to_string(path)
+        .with_context(|| format!("read evaluation barcodes {}", path.display()))?;
+    let cell_ids: HbMap<u32, usize> = cells.iter().enumerate().map(|(i, &b)| (b, i)).collect();
+    let mut selected = vec![false; cells.len()];
+    for (line, text) in text.lines().enumerate() {
+        let barcode = text.trim();
+        if barcode.is_empty() {
+            continue;
+        }
+        let barcode = barcode.strip_suffix("-1").unwrap_or(barcode);
+        let packed = if barcode.len() == 16 {
+            umi::pack(barcode.as_bytes())
+        } else {
+            None
+        }
+        .with_context(|| {
+            format!(
+                "{}:{}: expected a 16-base A/C/G/T barcode (optional -1 suffix)",
+                path.display(),
+                line + 1
+            )
+        })?;
+        let &cell = cell_ids.get(&packed).with_context(|| {
+            format!(
+                "{}:{}: barcode {barcode} is not in the archive",
+                path.display(),
+                line + 1
+            )
+        })?;
+        if std::mem::replace(&mut selected[cell], true) {
+            bail!(
+                "{}:{}: duplicate evaluation barcode {barcode}",
+                path.display(),
+                line + 1
+            );
+        }
+    }
+    if !selected.iter().any(|v| *v) {
+        bail!("evaluation barcode list is empty");
+    }
+    Ok(selected)
 }
 
 fn read_em_groups(path: &PathBuf, cells: &[u32], collapse: bool) -> Result<crate::rows::EmGroups> {
@@ -2586,6 +2653,23 @@ fn configure_em_allocator() {}
 
 pub fn run_em(args: EmArgs) -> Result<()> {
     configure_em_allocator();
+    let support_memory_budget = args
+        .support_memory_mib
+        .checked_mul(1 << 20)
+        .context("--support-memory-mib is too large")?;
+    let mut selected = std::collections::HashSet::new();
+    for mode in &args.modes {
+        if !selected.insert(mode) {
+            bail!("duplicate EM mode {mode}");
+        }
+        if args.groups.is_none() && !["uniform", "cell", "pooled", "blend"].contains(&mode.as_str())
+        {
+            bail!("EM mode {mode} requires --groups");
+        }
+    }
+    if args.emit.is_some() && !args.modes.is_empty() && !args.modes.iter().any(|m| m == "pooled") {
+        bail!("--emit requires pooled among --modes");
+    }
     if !args.mask.is_finite() || !(0.0..=1.0).contains(&args.mask) {
         bail!("--mask must be finite and between 0 and 1");
     }
@@ -2639,7 +2723,7 @@ pub fn run_em(args: EmArgs) -> Result<()> {
     let anno = anno::Annotation::from_path(&args.gtf)?;
     if args.star {
         let x = read_archive(&args.archive)?;
-        let m = crate::rows::em_star_matrix(&x, &anno);
+        let m = crate::rows::em_star_matrix(&x, &anno, args.gene_full, args.solo_strand.into());
         let out_dir = args.emit.as_ref().context("--star requires --emit")?;
         let barcodes = args
             .barcodes
@@ -2703,6 +2787,18 @@ pub fn run_em(args: EmArgs) -> Result<()> {
         }
         mtx.flush()?;
         feat.flush()?;
+        std::fs::write(
+            out_dir.join("metadata.json"),
+            serde_json::to_vec_pretty(&serde_json::json!({
+                "counting_model": if args.gene_full { "GeneFull" } else { "Gene" },
+                "strand_policy": replay_strand_name(args.solo_strand),
+                "algorithm": "STAR-style per-cell EM",
+                "layer": "unique plus fractional multi-only counts",
+                "counting_unit": "unique replay UMIs after one-mismatch collapse plus fractional multi-only raw UMI classes",
+                "archive": args.archive,
+                "annotation": args.gtf,
+            }))?,
+        )?;
         eprintln!(
             "wrote UniqueAndMult-EM ({} entries) to {}",
             triplets.len(),
@@ -2716,6 +2812,7 @@ pub fn run_em(args: EmArgs) -> Result<()> {
     let mut group_names: Vec<String> = Vec::new();
     let mut group_eval_cells = 0usize;
     let mut evaluation_counts = serde_json::Value::Null;
+    let mut support_storage = serde_json::Value::Null;
     let (recovered, cells) = if args.eager {
         let x = read_archive(&args.archive)?;
         let recovered = crate::rows::em_experiment(
@@ -2726,11 +2823,18 @@ pub fn run_em(args: EmArgs) -> Result<()> {
             args.alpha,
             args.plot.is_some().then_some(&mut cals),
             args.gene_full,
+            args.solo_strand.into(),
         );
         (recovered, x.cells)
     } else {
         let mut archive = StreamingReplayArchive::open(&args.archive)?;
-        let em = archive.packed_em_accumulator(&anno, args.gene_full)?;
+        let em = archive.packed_em_accumulator(
+            &anno,
+            args.gene_full,
+            args.solo_strand.into(),
+            support_memory_budget,
+        )?;
+        support_storage = em.support_storage();
         let cells = std::mem::take(&mut archive.x.cells);
         let cell_of_class = std::mem::take(&mut archive.cell_of_class);
         drop(archive);
@@ -2754,9 +2858,18 @@ pub fn run_em(args: EmArgs) -> Result<()> {
             .as_ref()
             .map(|path| read_em_groups(path, &cells, args.collapse_groups))
             .transpose()?;
+        let evaluation_cells = args
+            .eval_barcodes
+            .as_ref()
+            .map(|path| read_em_evaluation_barcodes(path, &cells))
+            .transpose()?;
+        let evaluation_cells = evaluation_cells
+            .as_deref()
+            .or_else(|| groups.as_ref().map(|g| g.eval_cell.as_slice()));
+        group_eval_cells =
+            evaluation_cells.map_or(cells.len(), |v| v.iter().filter(|b| **b).count());
         if let Some(groups) = &groups {
             group_names = groups.names.clone();
-            group_eval_cells = groups.eval_cell.iter().filter(|v| **v).count();
             eprintln!(
                 "hierarchical EM: {} groups, {} scored cells{}",
                 groups.names.len(),
@@ -2767,10 +2880,8 @@ pub fn run_em(args: EmArgs) -> Result<()> {
                     ""
                 }
             );
-        } else {
-            group_eval_cells = cells.len();
         }
-        evaluation_counts = packed.evaluation_counts(groups.as_ref());
+        evaluation_counts = packed.evaluation_counts(evaluation_cells);
         let recovered = packed.run(
             &anno,
             args.alpha,
@@ -2796,6 +2907,8 @@ pub fn run_em(args: EmArgs) -> Result<()> {
             args.plot.is_some().then_some(&mut cals),
             args.metrics_json.is_some().then_some(&mut metrics),
             args.metrics_json.is_some().then_some(&mut paired_metrics),
+            evaluation_cells,
+            &args.modes,
         );
         (recovered, cells)
     };
@@ -2895,8 +3008,11 @@ pub fn run_em(args: EmArgs) -> Result<()> {
         });
         document["counting_model"] =
             serde_json::json!(if args.gene_full { "GeneFull" } else { "Gene" });
-        document["strand_policy"] = serde_json::json!("forward");
+        document["strand_policy"] = serde_json::json!(replay_strand_name(args.solo_strand));
         document["evaluation_counts"] = evaluation_counts;
+        document["support_storage"] = support_storage;
+        document["evaluation_barcodes_file"] = serde_json::json!(args.eval_barcodes);
+        document["requested_modes"] = serde_json::json!(args.modes);
         std::fs::write(path, serde_json::to_vec_pretty(&document)?)
             .with_context(|| format!("write EM metrics {}", path.display()))?;
     }
@@ -2979,7 +3095,7 @@ pub fn run_em(args: EmArgs) -> Result<()> {
             out_dir.join("metadata.json"),
             serde_json::to_vec_pretty(&serde_json::json!({
                 "counting_model": if args.gene_full { "GeneFull" } else { "Gene" },
-                "strand_policy": "forward",
+                "strand_policy": replay_strand_name(args.solo_strand),
                 "counting_unit": "fractional responsibility per UMI class before one-mismatch collapse",
                 "layer": "additive multi-only classes",
                 "archive": args.archive,

--- a/crates/aie/src/devcmd.rs
+++ b/crates/aie/src/devcmd.rs
@@ -34,7 +34,7 @@ enum Command {
     /// Evaluate exact path/length geometry, independent streams, and geometry sharing.
     PathBench(crate::pathbench::Args),
     /// Run multimapper-recovery modes and masked-evidence scoring.
-    Em(crate::archivecmd::EmArgs),
+    Em(Box<crate::archivecmd::EmArgs>),
 }
 
 pub fn run(args: Args) -> Result<()> {
@@ -50,7 +50,7 @@ pub fn run(args: Args) -> Result<()> {
         Command::StructuralBench(args) => crate::structuralbench::run(args),
         Command::SparseBench(args) => crate::sparsebench::run(args),
         Command::PathBench(args) => crate::pathbench::run(args),
-        Command::Em(args) => crate::archivecmd::run_em(args),
+        Command::Em(args) => crate::archivecmd::run_em(*args),
     }
 }
 

--- a/crates/aie/src/rows.rs
+++ b/crates/aie/src/rows.rs
@@ -761,6 +761,8 @@ struct PackedEmShard {
     target_genes: Vec<u32>,
     target_local: Vec<u32>,
     target_truth: Vec<u32>,
+    masked_cells: Vec<u32>,
+    truth_lost_cells: Vec<u32>,
 }
 
 impl PackedEmShard {
@@ -880,6 +882,7 @@ pub(crate) struct PackedPairedMetrics {
 pub(crate) struct PackedEmAccumulator {
     n_classes: u32,
     gene_count: usize,
+    gene_full: Option<anno::assign::GeneFullIndex>,
     bam2anno: Vec<Option<u32>>,
     shards: Vec<Vec<EmSupport>>,
     spill: Option<EmSupportSpill>,
@@ -1001,6 +1004,7 @@ impl PackedEmAccumulator {
         x: &Extracted,
         anno: &anno::Annotation,
         expected_molecules: usize,
+        gene_full: bool,
     ) -> Result<Self> {
         if anno.gene_ids.len() > EM_GENE_MASK as usize + 1 {
             bail!("annotation has too many genes for packed EM labels");
@@ -1013,6 +1017,7 @@ impl PackedEmAccumulator {
         Ok(Self {
             n_classes: x.n_classes,
             gene_count: anno.gene_ids.len(),
+            gene_full: gene_full.then(|| anno::assign::GeneFullIndex::new(anno)),
             bam2anno,
             shards: (0..EM_SHARDS).map(|_| Vec::new()).collect(),
             spill: (expected_molecules.saturating_mul(std::mem::size_of::<EmSupport>())
@@ -1037,7 +1042,22 @@ impl PackedEmAccumulator {
         for m in mols {
             let shard = m.cell as usize % EM_SHARDS;
             let mut handle = |r: Row| {
-                if row_genes(&r, x, anno, &self.bam2anno, MmMissing::DropRow, s).is_none()
+                let missing = if self.gene_full.is_some() {
+                    MmMissing::SkipAlt
+                } else {
+                    MmMissing::DropRow
+                };
+                if row_genes_model(
+                    &r,
+                    x,
+                    anno,
+                    &self.bam2anno,
+                    missing,
+                    anno::assign::SoloStrand::Forward,
+                    self.gene_full.as_ref(),
+                    s,
+                )
+                .is_none()
                     || s.genes.is_empty()
                 {
                     return;
@@ -1265,6 +1285,8 @@ fn build_em_shard(
     let mut target_cells = Vec::new();
     let mut target_genes = Vec::new();
     let mut target_truth = Vec::new();
+    let mut masked_cells = Vec::new();
+    let mut truth_lost_cells = Vec::new();
     let mut unique_events: Vec<u64> = Vec::new();
     let mut key_events: Vec<u64> = Vec::new();
     let mut counters = EmCounters::default();
@@ -1308,6 +1330,7 @@ fn build_em_shard(
             let truth = unique_genes[0];
             if em_masked(seed, cell, class, mask_frac) {
                 counters.masked += 1;
+                masked_cells.push(cell);
                 let cands: SmallVec<[u32; 4]> = class_genes
                     .iter()
                     .filter(|(_, flags)| flags & EM_MULTI_FLAG != 0)
@@ -1326,6 +1349,7 @@ fn build_em_shard(
                     )?;
                 } else {
                     counters.truth_lost += 1;
+                    truth_lost_cells.push(cell);
                 }
             } else {
                 let key = cell_gene_key(cell, truth);
@@ -1386,6 +1410,8 @@ fn build_em_shard(
             target_genes,
             target_local,
             target_truth,
+            masked_cells,
+            truth_lost_cells,
         },
         counters,
     ))
@@ -1688,6 +1714,32 @@ fn paired_metrics(
 }
 
 impl PackedEm {
+    pub(crate) fn evaluation_counts(&self, groups: Option<&EmGroups>) -> serde_json::Value {
+        let selected = |cell: &&u32| groups.is_none_or(|g| g.eval_cell[**cell as usize]);
+        let masked: usize = self
+            .shards
+            .iter()
+            .map(|s| s.masked_cells.iter().filter(selected).count())
+            .sum();
+        let truth_lost: usize = self
+            .shards
+            .iter()
+            .map(|s| s.truth_lost_cells.iter().filter(selected).count())
+            .sum();
+        serde_json::json!({
+            "unit": "UMI classes before one-mismatch collapse",
+            "scored_population_masked_classes": masked,
+            "scored_population_truth_lost_classes": truth_lost,
+            "scored_population_evaluable_classes": masked - truth_lost,
+            "all_input_single_gene_classes": self.counters.single,
+            "all_input_mixed_classes": self.counters.mixed,
+            "all_input_multi_only_classes": self.counters.multi_only,
+            "all_input_masked_classes": self.counters.masked,
+            "all_input_truth_lost_classes": self.counters.truth_lost,
+            "prior_fit_scope": "all input archive barcodes after masking",
+        })
+    }
+
     /// Run the four fixed sharing modes, plus optional group, additive-hierarchical,
     /// candidate-normalized convex, posterior-mean Dirichlet-proxy, and monotone depth-hybrid
     /// modes, over packed CSR labels. Each iteration walks shards in a fixed order and classes in
@@ -2612,9 +2664,14 @@ pub fn em_experiment(
     seed: u64,
     alpha: f64,
     cal_out: Option<&mut Vec<EmCalibrationRow>>,
+    gene_full: bool,
 ) -> Option<FxHashMap<(u32, u32), f64>> {
-    let bam2anno: Vec<Option<u32>> =
-        x.chrom_names.iter().map(|n| anno.chrom_ids.get(n).copied()).collect();
+    let gene_full = gene_full.then(|| anno::assign::GeneFullIndex::new(anno));
+    let bam2anno: Vec<Option<u32>> = x
+        .chrom_names
+        .iter()
+        .map(|n| anno.chrom_ids.get(n).copied())
+        .collect();
     let rows = flatten(&x.mols);
     // Per row: candidate genes + weight, tagged unique(1 gene) / multi(>1). DropRow preserves the
     // historical semantics: an mm alternative on an unannotated chromosome discards the row.
@@ -2622,7 +2679,21 @@ pub fn em_experiment(
     let per_row: Vec<Option<EmRowEvidence>> = rows
         .par_iter()
         .map_init(RowScratch::default, |s, r| {
-            row_genes(r, x, anno, &bam2anno, MmMissing::DropRow, s)?;
+            let missing = if gene_full.is_some() {
+                MmMissing::SkipAlt
+            } else {
+                MmMissing::DropRow
+            };
+            row_genes_model(
+                r,
+                x,
+                anno,
+                &bam2anno,
+                missing,
+                anno::assign::SoloStrand::Forward,
+                gene_full.as_ref(),
+                s,
+            )?;
             if s.genes.is_empty() {
                 None
             } else {
@@ -4491,6 +4562,107 @@ pub(crate) fn replay_rows_model(
 #[cfg(test)]
 mod genefull_replay_tests {
     use super::*;
+
+    #[test]
+    fn genefull_em_masks_nested_candidates_and_audits_scored_classes() {
+        let path =
+            std::env::temp_dir().join(format!("gravlax-genefull-em-{}.gtf", std::process::id()));
+        let mut gtf = String::new();
+        for (gene, start, end) in [
+            ("A", 101, 200),
+            ("A", 401, 500),
+            ("B", 251, 300),
+            ("C", 601, 700),
+            ("D", 801, 900),
+        ] {
+            gtf.push_str(&format!("chr1\tX\texon\t{start}\t{end}\t.\t+\t.\tgene_id \"{gene}\"; transcript_id \"{gene}1\";\n"));
+        }
+        std::fs::write(&path, gtf).unwrap();
+        let anno = anno::Annotation::from_gtf(&path).unwrap();
+        std::fs::remove_file(path).unwrap();
+        let molecule = |class, cell, pos| MolRec {
+            cell,
+            umi_class: class,
+            chrom: 0,
+            strand_rev: false,
+            chains: smallvec::smallvec![MolChain {
+                weight: 1,
+                reps: smallvec::smallvec![(pos, 0)]
+            }],
+            mms: SmallVec::new(),
+        };
+        let mut mols = vec![
+            molecule(0, 0, 110),
+            molecule(0, 0, 260),
+            molecule(1, 0, 210),
+            molecule(2, 0, 260),
+            molecule(3, 0, 110),
+            molecule(3, 0, 610),
+            molecule(4, 1, 110),
+            molecule(4, 1, 260),
+            molecule(5, 0, 210),
+        ];
+        mols[5].chains.clear();
+        mols[5].mms.push((610, 0, 0, 1));
+        mols[8].chains.clear();
+        mols[8].mms.push((210, 0, 1, 1));
+        let alt = |chrom, offset| PatAlt {
+            chrom,
+            offset,
+            strand_flip: false,
+            shape: SAME_SHAPE,
+        };
+        let x = Extracted {
+            mols,
+            edges: vec![],
+            cells: vec![0, 1],
+            shapes: vec![Shape {
+                blocks: vec![(0, 20)],
+            }],
+            patterns: vec![vec![alt(0, 0), alt(0, 200)], vec![alt(1, 0), alt(0, 0)]],
+            n_classes: 6,
+            chrom_names: vec!["chr1".into(), "missing".into()],
+        };
+        for full in [false, true] {
+            let mut em = PackedEmAccumulator::new(&x, &anno, x.mols.len(), full).unwrap();
+            // Split repeated classes across decoder batches; the global class is still masked once.
+            for m in &x.mols {
+                em.add_archive_chunks(&[vec![m.clone()]], &x, &anno)
+                    .unwrap();
+            }
+            let packed = em.finish(&[0, 0, 0, 0, 1, 0], 1.0, 7).unwrap();
+            let all = packed.evaluation_counts(None);
+            if full {
+                assert_eq!(all["all_input_single_gene_classes"], 2);
+                assert_eq!(all["all_input_multi_only_classes"], 1);
+                assert_eq!(all["scored_population_masked_classes"], 3);
+                assert_eq!(all["scored_population_truth_lost_classes"], 1);
+                assert_eq!(all["scored_population_evaluable_classes"], 2);
+                let groups = EmGroups {
+                    cell_group: vec![0, 0],
+                    eval_cell: vec![true, false],
+                    names: vec!["fixed".into()],
+                };
+                let fixed = packed.evaluation_counts(Some(&groups));
+                assert_eq!(fixed["scored_population_masked_classes"], 2);
+                assert_eq!(fixed["scored_population_truth_lost_classes"], 1);
+                assert_eq!(fixed["scored_population_evaluable_classes"], 1);
+                let target = &packed.shards[0];
+                let at = target
+                    .target_truth
+                    .iter()
+                    .position(|&truth| truth == 0)
+                    .unwrap();
+                assert_eq!(&target.target_genes[target.target_range(at)], &[0, 1]);
+                // Unique A evidence for the masked class cannot leak into the fitted prior.
+                assert_eq!(packed.global_base[0], 2.0);
+            } else {
+                assert_eq!(all["scored_population_masked_classes"], 1);
+                assert_eq!(all["scored_population_truth_lost_classes"], 1);
+                assert_eq!(all["scored_population_evaluable_classes"], 0);
+            }
+        }
+    }
 
     #[test]
     fn genefull_alternatives_global_collapse_and_statistic_units() {

--- a/crates/aie/src/rows.rs
+++ b/crates/aie/src/rows.rs
@@ -452,9 +452,15 @@ pub fn velocity_rows_stranded(
 /// reads' gene sets; EM initializes at unique+uniform, zeroes counts < 0.01 each iteration, and
 /// stops at max-abs-change < 0.01 or 100 iterations. Returns unique + EM-multimapper totals per
 /// (cell, gene) — the UniqueAndMult-EM matrix.
-pub fn em_star_matrix(x: &Extracted, anno: &anno::Annotation) -> FxHashMap<(u32, u32), f64> {
-    // Unique side = the byte-exact Gene replay.
-    let (unique_counts, _, _) = replay_rows(x, anno);
+pub fn em_star_matrix(
+    x: &Extracted,
+    anno: &anno::Annotation,
+    gene_full: bool,
+    solo_strand: anno::assign::SoloStrand,
+) -> FxHashMap<(u32, u32), f64> {
+    // Unique counts and ambiguous candidates must use the same counting model and strand.
+    let (unique_counts, _, _) = replay_rows_model(x, anno, solo_strand, gene_full);
+    let gene_full = gene_full.then(|| anno::assign::GeneFullIndex::new(anno));
 
     let bam2anno: Vec<Option<u32>> =
         x.chrom_names.iter().map(|n| anno.chrom_ids.get(n).copied()).collect();
@@ -462,8 +468,21 @@ pub fn em_star_matrix(x: &Extracted, anno: &anno::Annotation) -> FxHashMap<(u32,
     let per_row: Vec<Option<(u32, u32, Vec<u32>)>> = rows
         .par_iter()
         .map_init(RowScratch::default, |s, r| {
-            row_genes(r, x, anno, &bam2anno, MmMissing::SkipAlt, s)?;
-            if s.genes.is_empty() { None } else { Some((r.cell, r.umi_class, s.genes.clone())) }
+            row_genes_model(
+                r,
+                x,
+                anno,
+                &bam2anno,
+                MmMissing::SkipAlt,
+                solo_strand,
+                gene_full.as_ref(),
+                s,
+            )?;
+            if s.genes.is_empty() {
+                None
+            } else {
+                Some((r.cell, r.umi_class, s.genes.clone()))
+            }
         })
         .collect();
 
@@ -719,6 +738,7 @@ pub fn multigene_audit_stranded(
 // observed (class, gene) support item survive classification.  Cell shards make the sort/reduce
 // working set bounded and give the EM a deterministic reduction order.
 const EM_SHARDS: usize = 64;
+#[cfg(test)]
 const EM_IN_MEMORY_SUPPORT_BUDGET: usize = 512 << 20;
 const EM_GENE_MASK: u32 = (1 << 30) - 1;
 const EM_MULTI_FLAG: u32 = 1 << 30;
@@ -733,6 +753,7 @@ struct EmSupport {
 }
 
 #[derive(Default, Clone, Copy)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
 struct EmCounters {
     single: u64,
     mixed: u64,
@@ -751,6 +772,7 @@ impl std::ops::AddAssign for EmCounters {
     }
 }
 
+#[cfg_attr(test, derive(Debug, PartialEq))]
 struct PackedEmShard {
     // Sorted packed (cell,gene) universe needed by either the base counts or a target.
     cell_gene_keys: Vec<u64>,
@@ -774,6 +796,7 @@ impl PackedEmShard {
 
 /// Packed, cell-sharded input to the recovery EM.  It contains no molecule/row table, no hash
 /// table, and no per-class or per-target heap allocation.
+#[cfg_attr(test, derive(Debug, PartialEq))]
 pub(crate) struct PackedEm {
     shards: Vec<PackedEmShard>,
     global_base: Vec<f64>,
@@ -883,9 +906,13 @@ pub(crate) struct PackedEmAccumulator {
     n_classes: u32,
     gene_count: usize,
     gene_full: Option<anno::assign::GeneFullIndex>,
+    solo_strand: anno::assign::SoloStrand,
     bam2anno: Vec<Option<u32>>,
     shards: Vec<Vec<EmSupport>>,
     spill: Option<EmSupportSpill>,
+    support_memory_budget: usize,
+    small_decode_window: bool,
+    peak_retained_support_bytes: usize,
 }
 
 struct EmSupportSpill {
@@ -1005,6 +1032,8 @@ impl PackedEmAccumulator {
         anno: &anno::Annotation,
         expected_molecules: usize,
         gene_full: bool,
+        solo_strand: anno::assign::SoloStrand,
+        support_memory_budget: usize,
     ) -> Result<Self> {
         if anno.gene_ids.len() > EM_GENE_MASK as usize + 1 {
             bail!("annotation has too many genes for packed EM labels");
@@ -1018,17 +1047,29 @@ impl PackedEmAccumulator {
             n_classes: x.n_classes,
             gene_count: anno.gene_ids.len(),
             gene_full: gene_full.then(|| anno::assign::GeneFullIndex::new(anno)),
+            solo_strand,
             bam2anno,
             shards: (0..EM_SHARDS).map(|_| Vec::new()).collect(),
-            spill: (expected_molecules.saturating_mul(std::mem::size_of::<EmSupport>())
-                > EM_IN_MEMORY_SUPPORT_BUDGET)
-                .then(EmSupportSpill::new)
-                .transpose()?,
+            spill: None,
+            support_memory_budget,
+            small_decode_window: expected_molecules
+                .saturating_mul(std::mem::size_of::<EmSupport>())
+                > support_memory_budget,
+            peak_retained_support_bytes: 0,
         })
     }
 
-    pub(crate) fn spills_supports(&self) -> bool {
-        self.spill.is_some()
+    pub(crate) fn small_decode_window(&self) -> bool {
+        self.small_decode_window
+    }
+
+    pub(crate) fn support_storage(&self) -> serde_json::Value {
+        serde_json::json!({
+            "spilled": self.spill.is_some(),
+            "retained_support_budget_bytes": self.support_memory_budget,
+            "peak_retained_support_capacity_bytes": self.peak_retained_support_bytes,
+            "scope": "retained compact support arrays; excludes decoder batches, spill buffers and final EM state",
+        })
     }
 
     fn classify(
@@ -1053,7 +1094,7 @@ impl PackedEmAccumulator {
                     anno,
                     &self.bam2anno,
                     missing,
-                    anno::assign::SoloStrand::Forward,
+                    self.solo_strand,
                     self.gene_full.as_ref(),
                     s,
                 )
@@ -1127,6 +1168,26 @@ impl PackedEmAccumulator {
                 compact_em_supports(support);
             }
         });
+        // Decide from actual compact (class,gene,flags) supports, not one guessed word per
+        // molecule. GeneFull can expand a record into many candidate genes. Include existing
+        // capacity and the incoming batch before reserving persistent arrays; once spilled,
+        // stay on disk. Decoder/worker scratch and final CSR state are separate working sets.
+        if self.spill.is_none() {
+            let incoming: usize = parts.iter().flatten().map(Vec::len).sum();
+            let retained: usize = self.shards.iter().map(Vec::capacity).sum();
+            if retained
+                .saturating_add(incoming)
+                .saturating_mul(std::mem::size_of::<EmSupport>())
+                > self.support_memory_budget
+            {
+                let mut spill = EmSupportSpill::new()?;
+                for (shard, support) in self.shards.iter_mut().enumerate() {
+                    spill.append(shard, support)?;
+                    *support = Vec::new();
+                }
+                self.spill = Some(spill);
+            }
+        }
         if let Some(spill) = &mut self.spill {
             for worker_shards in &parts {
                 for (shard, support) in worker_shards.iter().enumerate() {
@@ -1142,6 +1203,10 @@ impl PackedEmAccumulator {
                     dst.append(src);
                 }
             }
+            self.peak_retained_support_bytes = self.peak_retained_support_bytes.max(
+                self.shards.iter().map(Vec::capacity).sum::<usize>()
+                    * std::mem::size_of::<EmSupport>(),
+            );
         }
         Ok(())
     }
@@ -1714,8 +1779,8 @@ fn paired_metrics(
 }
 
 impl PackedEm {
-    pub(crate) fn evaluation_counts(&self, groups: Option<&EmGroups>) -> serde_json::Value {
-        let selected = |cell: &&u32| groups.is_none_or(|g| g.eval_cell[**cell as usize]);
+    pub(crate) fn evaluation_counts(&self, evaluation_cells: Option<&[bool]>) -> serde_json::Value {
+        let selected = |cell: &&u32| evaluation_cells.is_none_or(|cells| cells[**cell as usize]);
         let masked: usize = self
             .shards
             .iter()
@@ -1766,6 +1831,8 @@ impl PackedEm {
         cal_out: Option<&mut Vec<EmCalibrationRow>>,
         metrics_out: Option<&mut Vec<PackedModeMetrics>>,
         paired_metrics_out: Option<&mut Vec<PackedPairedMetrics>>,
+        evaluation_cells: Option<&[bool]>,
+        selected_modes: &[String],
     ) -> Option<FxHashMap<(u32, u32), f64>> {
         if let Some(groups) = groups {
             assert_eq!(groups.cell_group.len(), groups.eval_cell.len());
@@ -1780,7 +1847,7 @@ impl PackedEm {
                     .zip(&s.target_cells)
                     .filter(|(truth, cell)| {
                         **truth != EM_NO_TRUTH
-                            && groups.is_none_or(|g| g.eval_cell[**cell as usize])
+                            && evaluation_cells.is_none_or(|v| v[**cell as usize])
                     })
                     .count()
             })
@@ -1816,6 +1883,10 @@ impl PackedEm {
                 ("depth-hybrid", 8),
             ]);
         }
+        if !selected_modes.is_empty() {
+            modes.retain(|(name, _)| selected_modes.iter().any(|s| s == name));
+        }
+        let needs_groups = modes.iter().any(|(_, mode)| *mode >= 4);
         let mut cal_rows = Vec::new();
         let mut metric_rows = Vec::new();
         let collect_paired = paired_metrics_out.is_some()
@@ -1826,7 +1897,7 @@ impl PackedEm {
         let mut target_observations: Vec<(String, Vec<PackedTargetObservation>)> = Vec::new();
         let mut impact: Option<(Vec<Vec<f64>>, Vec<f64>, u64)> = None;
 
-        let group_base = groups.map(|groups| {
+        let group_base = groups.filter(|_| needs_groups).map(|groups| {
             let mut base = vec![0.0f64; groups.names.len() * self.global_base.len()];
             for shard in &self.shards {
                 for (&key, &count) in shard.cell_gene_keys.iter().zip(&shard.unique_base) {
@@ -1850,7 +1921,7 @@ impl PackedEm {
                     for i in 0..shard.target_cells.len() {
                         let truth = shard.target_truth[i];
                         if truth == EM_NO_TRUTH
-                            || groups.is_some_and(|g| !g.eval_cell[shard.target_cells[i] as usize])
+                            || evaluation_cells.is_some_and(|v| !v[shard.target_cells[i] as usize])
                         {
                             continue;
                         }
@@ -2081,7 +2152,7 @@ impl PackedEm {
                             }
                             if final_iter
                                 && truth != EM_NO_TRUTH
-                                && groups.is_none_or(|g| g.eval_cell[cell])
+                                && evaluation_cells.is_none_or(|v| v[cell])
                             {
                                 let truth_i = shard.target_genes[range.clone()]
                                     .iter()
@@ -2193,7 +2264,6 @@ impl PackedEm {
                         .iter()
                         .find(|(candidate, _)| candidate == name)
                         .map(|(_, observations)| observations.as_slice())
-                        .expect("paired EM mode was not collected")
                 };
                 *out = [
                     ("depth-hybrid", "pooled"),
@@ -2203,8 +2273,13 @@ impl PackedEm {
                     ("convex", "pooled"),
                 ]
                 .into_iter()
-                .map(|(candidate, reference)| {
-                    paired_metrics(candidate, find(candidate), reference, find(reference))
+                .filter_map(|(candidate, reference)| {
+                    Some(paired_metrics(
+                        candidate,
+                        find(candidate)?,
+                        reference,
+                        find(reference)?,
+                    ))
                 })
                 .collect();
             }
@@ -2657,6 +2732,7 @@ classes with gene evidence: single-gene-counted 4 | MULTI-ONLY (fully discarded,
 /// vectors, masks a seeded 20% of mixed classes down to their multi-gene evidence (truth is the
 /// gene supported by their unique rows), and scores per-cell, pooled, and blended EM against a
 /// uniform baseline.
+#[allow(clippy::too_many_arguments)]
 pub fn em_experiment(
     x: &Extracted,
     anno: &anno::Annotation,
@@ -2665,6 +2741,7 @@ pub fn em_experiment(
     alpha: f64,
     cal_out: Option<&mut Vec<EmCalibrationRow>>,
     gene_full: bool,
+    solo_strand: anno::assign::SoloStrand,
 ) -> Option<FxHashMap<(u32, u32), f64>> {
     let gene_full = gene_full.then(|| anno::assign::GeneFullIndex::new(anno));
     let bam2anno: Vec<Option<u32>> = x
@@ -2690,7 +2767,7 @@ pub fn em_experiment(
                 anno,
                 &bam2anno,
                 missing,
-                anno::assign::SoloStrand::Forward,
+                solo_strand,
                 gene_full.as_ref(),
                 s,
             )?;
@@ -3149,19 +3226,6 @@ enum MmMissing {
 /// Candidate genes for one row, into `s.genes` — same gene order as the old allocating code.
 /// Returns `None` exactly when the old code early-returned before inspecting genes: a unique row
 /// on an unannotated chromosome, or (with `DropRow`) any mm alternative on one.
-fn row_genes(
-    r: &Row,
-    x: &Extracted,
-    anno: &anno::Annotation,
-    bam2anno: &[Option<u32>],
-    mm_missing: MmMissing,
-    s: &mut RowScratch,
-) -> Option<()> {
-    row_genes_stranded(
-        r, x, anno, bam2anno, mm_missing, anno::assign::SoloStrand::Forward, s,
-    )
-}
-
 fn row_genes_stranded(
     r: &Row,
     x: &Extracted,
@@ -3185,8 +3249,8 @@ fn row_genes_model(
     gene_full: Option<&anno::assign::GeneFullIndex>,
     s: &mut RowScratch,
 ) -> Option<()> {
-    // One-entry memo: same placement key → same genes (s.genes still holds them). The mm-missing
-    // mode is constant across one pass, so it cannot alias between cached entries.
+    // One-entry memo: same placement key → same genes (s.genes still holds them). Annotation,
+    // counting model, strand policy and missing-contig policy are fixed for each scratch's pass.
     let key = (r.chrom, r.pos, r.shape, r.pattern, r.strand_rev);
     if s.last_key == Some(key) {
         return if s.last_none { None } else { Some(()) };
@@ -3196,10 +3260,26 @@ fn row_genes_model(
     s.genes.clear();
     if r.pattern == u32::MAX {
         let ac = (*bam2anno.get(r.chrom as usize)?)?;
-        placement_from_parts_into(&mut s.place, r.chrom, r.pos, r.strand_rev, &x.shapes[r.shape as usize], 1);
         if let Some(index) = gene_full {
-            index.genes_into(&s.place, ac, solo_strand, &mut s.genes);
+            index.genes_for_blocks_into(
+                ac,
+                r.strand_rev,
+                solo_strand,
+                x.shapes[r.shape as usize]
+                    .blocks
+                    .iter()
+                    .map(|&(off, len)| (r.pos + off, r.pos + off + len)),
+                &mut s.genes,
+            );
         } else {
+            placement_from_parts_into(
+                &mut s.place,
+                r.chrom,
+                r.pos,
+                r.strand_rev,
+                &x.shapes[r.shape as usize],
+                1,
+            );
             anno::assign::concordant_genes_stranded_into(
                 &s.place, anno, ac, solo_strand, &mut s.txbuf, &mut s.genes,
             );
@@ -3215,11 +3295,31 @@ fn row_genes_model(
             };
             let apos = (r.pos as i64 + alt.offset) as u32;
             let arev = r.strand_rev != alt.strand_flip;
-            let shape_id = if alt.shape == SAME_SHAPE { r.shape } else { alt.shape };
-            placement_from_parts_into(&mut s.place, alt.chrom, apos, arev, &x.shapes[shape_id as usize], 2);
-            if let Some(index) = gene_full {
-                index.genes_into(&s.place, ac, solo_strand, &mut s.alt_genes);
+            let shape_id = if alt.shape == SAME_SHAPE {
+                r.shape
             } else {
+                alt.shape
+            };
+            if let Some(index) = gene_full {
+                index.genes_for_blocks_into(
+                    ac,
+                    arev,
+                    solo_strand,
+                    x.shapes[shape_id as usize]
+                        .blocks
+                        .iter()
+                        .map(|&(off, len)| (apos + off, apos + off + len)),
+                    &mut s.alt_genes,
+                );
+            } else {
+                placement_from_parts_into(
+                    &mut s.place,
+                    alt.chrom,
+                    apos,
+                    arev,
+                    &x.shapes[shape_id as usize],
+                    2,
+                );
                 anno::assign::concordant_genes_stranded_into(
                     &s.place, anno, ac, solo_strand, &mut s.txbuf, &mut s.alt_genes,
                 );
@@ -4246,6 +4346,7 @@ pub(crate) struct ReplayRowsAccumulator<'a> {
 }
 
 impl<'a> ReplayRowsAccumulator<'a> {
+    #[cfg(test)]
     pub(crate) fn with_strand(
         x: &'a Extracted,
         anno: &'a anno::Annotation,
@@ -4398,6 +4499,7 @@ impl<'a> ReplayRowsAccumulator<'a> {
         self.shards = shards;
     }
 
+    #[cfg(test)]
     pub(crate) fn finish(self) -> (FxHashMap<(u32, u32), u32>, u64, u64) {
         let (counts, stats, total) = self.finish_with_stats();
         (counts, stats.assigned_representative_rows, total)
@@ -4528,6 +4630,7 @@ impl<'a> ReplayRowsAccumulator<'a> {
 
 /// Quantify one annotation from rows alone. The eager entry point remains the reference used by
 /// BAM, molecule-BAM, EM, velocity helpers, and `replay-rows --eager`.
+#[cfg(test)]
 pub fn replay_rows(
     x: &Extracted,
     anno: &anno::Annotation,
@@ -4537,6 +4640,7 @@ pub fn replay_rows(
 
 /// Strand-parameterized [`replay_rows`]. Existing callers retain `Forward` through the wrapper;
 /// the CLI selects this explicitly for non-3' chemistries.
+#[cfg(test)]
 pub fn replay_rows_stranded(
     x: &Extracted,
     anno: &anno::Annotation,
@@ -4562,6 +4666,119 @@ pub(crate) fn replay_rows_model(
 #[cfg(test)]
 mod genefull_replay_tests {
     use super::*;
+
+    #[test]
+    fn star_em_models_strands_and_mixed_classes() {
+        use anno::assign::SoloStrand::{Forward, Reverse, Unstranded};
+        let path =
+            std::env::temp_dir().join(format!("gravlax-star-strands-{}.gtf", std::process::id()));
+        std::fs::write(
+            &path,
+            concat!(
+                "chr1\tX\texon\t101\t200\t.\t+\t.\tgene_id \"A\"; transcript_id \"A\";\n",
+                "chr1\tX\texon\t401\t500\t.\t+\t.\tgene_id \"A\"; transcript_id \"A\";\n",
+                "chr1\tX\texon\t251\t300\t.\t+\t.\tgene_id \"B\"; transcript_id \"B\";\n",
+                "chr1\tX\texon\t101\t500\t.\t-\t.\tgene_id \"C\"; transcript_id \"C\";\n",
+            ),
+        )
+        .unwrap();
+        let anno = anno::Annotation::from_gtf(&path).unwrap();
+        std::fs::remove_file(path).unwrap();
+        let mut x = Extracted {
+            mols: [210, 260]
+                .into_iter()
+                .enumerate()
+                .map(|(class, pos)| MolRec {
+                    cell: 0,
+                    umi_class: class as u32,
+                    chrom: 0,
+                    strand_rev: false,
+                    chains: smallvec::smallvec![MolChain {
+                        weight: 1,
+                        reps: smallvec::smallvec![(pos, 0)]
+                    }],
+                    mms: SmallVec::new(),
+                })
+                .collect(),
+            edges: vec![],
+            cells: vec![0],
+            shapes: vec![Shape {
+                blocks: vec![(0, 20)],
+            }],
+            patterns: vec![],
+            n_classes: 2,
+            chrom_names: vec!["chr1".into()],
+        };
+        assert_eq!(
+            em_star_matrix(&x, &anno, false, Forward),
+            FxHashMap::from_iter([((0, 1), 1.0)])
+        );
+        // STAR stops once the largest change is below 0.01, before the minor component reaches zero.
+        assert_eq!(
+            em_star_matrix(&x, &anno, true, Forward),
+            FxHashMap::from_iter([((0, 0), 1.9921875), ((0, 1), 0.0078125)])
+        );
+        for full in [false, true] {
+            assert_eq!(
+                em_star_matrix(&x, &anno, full, Reverse),
+                FxHashMap::from_iter([((0, 2), 2.0)])
+            );
+            let unstranded = em_star_matrix(&x, &anno, full, Unstranded);
+            assert!((unstranded.values().sum::<f64>() - 2.0).abs() < 1e-12);
+            let forward = em_star_matrix(&x, &anno, full, Forward);
+            for m in &mut x.mols {
+                m.strand_rev = true;
+            }
+            assert_eq!(em_star_matrix(&x, &anno, full, Reverse), forward);
+            assert_eq!(em_star_matrix(&x, &anno, full, Unstranded), unstranded);
+            for m in &mut x.mols {
+                m.strand_rev = false;
+            }
+        }
+        // Unique and ambiguous records sharing a class must not count twice in STAR-style EM.
+        x.mols[1].umi_class = 0;
+        x.n_classes = 1;
+        assert_eq!(
+            em_star_matrix(&x, &anno, true, Forward),
+            FxHashMap::from_iter([((0, 0), 1.0)])
+        );
+        // An alternative may flip orientation relative to its anchor. Missing-contig
+        // alternatives do not erase the annotated candidates in the STAR-style path.
+        x.mols.truncate(1);
+        x.mols[0].chains.clear();
+        x.mols[0].mms.push((210, 0, 0, 1));
+        x.chrom_names.push("missing".into());
+        x.patterns.push(vec![
+            PatAlt {
+                chrom: 0,
+                offset: 0,
+                strand_flip: false,
+                shape: SAME_SHAPE,
+            },
+            PatAlt {
+                chrom: 0,
+                offset: 0,
+                strand_flip: true,
+                shape: SAME_SHAPE,
+            },
+            PatAlt {
+                chrom: 1,
+                offset: 0,
+                strand_flip: false,
+                shape: SAME_SHAPE,
+            },
+        ]);
+        for strand in [Forward, Reverse, Unstranded] {
+            assert_eq!(
+                em_star_matrix(&x, &anno, false, strand),
+                FxHashMap::from_iter([((0, 2), 1.0)])
+            );
+            assert_eq!(
+                em_star_matrix(&x, &anno, true, strand),
+                FxHashMap::from_iter([((0, 0), 0.5), ((0, 2), 0.5)])
+            );
+        }
+    }
 
     #[test]
     fn genefull_em_masks_nested_candidates_and_audits_scored_classes() {
@@ -4624,13 +4841,46 @@ mod genefull_replay_tests {
             chrom_names: vec!["chr1".into(), "missing".into()],
         };
         for full in [false, true] {
-            let mut em = PackedEmAccumulator::new(&x, &anno, x.mols.len(), full).unwrap();
+            let mut em = PackedEmAccumulator::new(
+                &x,
+                &anno,
+                x.mols.len(),
+                full,
+                anno::assign::SoloStrand::Forward,
+                EM_IN_MEMORY_SUPPORT_BUDGET,
+            )
+            .unwrap();
             // Split repeated classes across decoder batches; the global class is still masked once.
             for m in &x.mols {
                 em.add_archive_chunks(&[vec![m.clone()]], &x, &anno)
                     .unwrap();
             }
             let packed = em.finish(&[0, 0, 0, 0, 1, 0], 1.0, 7).unwrap();
+            for budget in [0, 16, 40] {
+                let mut spilled = PackedEmAccumulator::new(
+                    &x,
+                    &anno,
+                    0,
+                    full,
+                    anno::assign::SoloStrand::Forward,
+                    budget,
+                )
+                .unwrap();
+                for m in &x.mols {
+                    spilled
+                        .add_archive_chunks(&[vec![m.clone()]], &x, &anno)
+                        .unwrap();
+                }
+                assert!(
+                    spilled.spill.is_some(),
+                    "actual supports must trigger spill even with a zero record estimate"
+                );
+                let spill_dir = spilled.spill.as_ref().unwrap().dir.clone();
+                assert!(spilled.peak_retained_support_bytes <= budget);
+                let observed = spilled.finish(&[0, 0, 0, 0, 1, 0], 1.0, 7).unwrap();
+                assert_eq!(observed, packed);
+                assert!(!spill_dir.exists(), "completed spill must be cleaned up");
+            }
             let all = packed.evaluation_counts(None);
             if full {
                 assert_eq!(all["all_input_single_gene_classes"], 2);
@@ -4643,7 +4893,7 @@ mod genefull_replay_tests {
                     eval_cell: vec![true, false],
                     names: vec!["fixed".into()],
                 };
-                let fixed = packed.evaluation_counts(Some(&groups));
+                let fixed = packed.evaluation_counts(Some(&groups.eval_cell));
                 assert_eq!(fixed["scored_population_masked_classes"], 2);
                 assert_eq!(fixed["scored_population_truth_lost_classes"], 1);
                 assert_eq!(fixed["scored_population_evaluable_classes"], 1);

--- a/crates/aie/src/rows.rs
+++ b/crates/aie/src/rows.rs
@@ -3100,6 +3100,20 @@ fn row_genes_stranded(
     solo_strand: anno::assign::SoloStrand,
     s: &mut RowScratch,
 ) -> Option<()> {
+    row_genes_model(r, x, anno, bam2anno, mm_missing, solo_strand, None, s)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn row_genes_model(
+    r: &Row,
+    x: &Extracted,
+    anno: &anno::Annotation,
+    bam2anno: &[Option<u32>],
+    mm_missing: MmMissing,
+    solo_strand: anno::assign::SoloStrand,
+    gene_full: Option<&anno::assign::GeneFullIndex>,
+    s: &mut RowScratch,
+) -> Option<()> {
     // One-entry memo: same placement key → same genes (s.genes still holds them). The mm-missing
     // mode is constant across one pass, so it cannot alias between cached entries.
     let key = (r.chrom, r.pos, r.shape, r.pattern, r.strand_rev);
@@ -3112,9 +3126,13 @@ fn row_genes_stranded(
     if r.pattern == u32::MAX {
         let ac = (*bam2anno.get(r.chrom as usize)?)?;
         placement_from_parts_into(&mut s.place, r.chrom, r.pos, r.strand_rev, &x.shapes[r.shape as usize], 1);
-        anno::assign::concordant_genes_stranded_into(
-            &s.place, anno, ac, solo_strand, &mut s.txbuf, &mut s.genes,
-        );
+        if let Some(index) = gene_full {
+            index.genes_into(&s.place, ac, solo_strand, &mut s.genes);
+        } else {
+            anno::assign::concordant_genes_stranded_into(
+                &s.place, anno, ac, solo_strand, &mut s.txbuf, &mut s.genes,
+            );
+        }
     } else {
         for alt in &x.patterns[r.pattern as usize] {
             let ac = match bam2anno.get(alt.chrom as usize).copied().flatten() {
@@ -3128,9 +3146,13 @@ fn row_genes_stranded(
             let arev = r.strand_rev != alt.strand_flip;
             let shape_id = if alt.shape == SAME_SHAPE { r.shape } else { alt.shape };
             placement_from_parts_into(&mut s.place, alt.chrom, apos, arev, &x.shapes[shape_id as usize], 2);
-            anno::assign::concordant_genes_stranded_into(
-                &s.place, anno, ac, solo_strand, &mut s.txbuf, &mut s.alt_genes,
-            );
+            if let Some(index) = gene_full {
+                index.genes_into(&s.place, ac, solo_strand, &mut s.alt_genes);
+            } else {
+                anno::assign::concordant_genes_stranded_into(
+                    &s.place, anno, ac, solo_strand, &mut s.txbuf, &mut s.alt_genes,
+                );
+            }
             for &g in &s.alt_genes {
                 if !s.genes.contains(&g) {
                     s.genes.push(g);
@@ -4118,6 +4140,28 @@ fn extract_rows_inner(
 type ReplayTuple = (u32, u32, u32, u32); // (cell, class, gene, weight)
 const REPLAY_SHARDS: usize = 64;
 
+/// Assignment counts over all consumed input, not restricted to called nuclei.
+/// A molecule record can contain several representative rows, and a UMI class
+/// can occur in several records. None of these units is a collapsed UMI.
+#[derive(Clone, Copy, Debug, Default, serde::Serialize, PartialEq, Eq)]
+pub(crate) struct AssignmentStats {
+    pub molecule_records: u64,
+    pub assigned_molecule_records: u64,
+    pub representative_rows: u64,
+    pub assigned_representative_rows: u64,
+    pub umi_classes: u64,
+    pub assigned_umi_classes: u64,
+}
+
+impl AssignmentStats {
+    fn add(&mut self, other: Self) {
+        self.molecule_records += other.molecule_records;
+        self.assigned_molecule_records += other.assigned_molecule_records;
+        self.representative_rows += other.representative_rows;
+        self.assigned_representative_rows += other.assigned_representative_rows;
+    }
+}
+
 /// Bounded input-side reducer. Only assignment tuples survive each decoded archive batch; final
 /// aggregation remains global, so chunk boundaries cannot affect UMI classes or counts.
 pub(crate) struct ReplayRowsAccumulator<'a> {
@@ -4125,8 +4169,9 @@ pub(crate) struct ReplayRowsAccumulator<'a> {
     anno: &'a anno::Annotation,
     bam2anno: Vec<Option<u32>>,
     solo_strand: anno::assign::SoloStrand,
+    gene_full: Option<anno::assign::GeneFullIndex>,
     shards: Vec<Vec<ReplayTuple>>,
-    n_assigned: u64,
+    stats: AssignmentStats,
 }
 
 impl<'a> ReplayRowsAccumulator<'a> {
@@ -4135,10 +4180,29 @@ impl<'a> ReplayRowsAccumulator<'a> {
         anno: &'a anno::Annotation,
         solo_strand: anno::assign::SoloStrand,
     ) -> Self {
-        let bam2anno: Vec<Option<u32>> =
-            x.chrom_names.iter().map(|n| anno.chrom_ids.get(n).copied()).collect();
-        Self { x, anno, bam2anno, solo_strand,
-            shards: (0..REPLAY_SHARDS).map(|_| Vec::new()).collect(), n_assigned: 0 }
+        Self::with_model(x, anno, solo_strand, false)
+    }
+
+    pub(crate) fn with_model(
+        x: &'a Extracted,
+        anno: &'a anno::Annotation,
+        solo_strand: anno::assign::SoloStrand,
+        gene_full: bool,
+    ) -> Self {
+        let bam2anno: Vec<Option<u32>> = x
+            .chrom_names
+            .iter()
+            .map(|n| anno.chrom_ids.get(n).copied())
+            .collect();
+        Self {
+            x,
+            anno,
+            bam2anno,
+            solo_strand,
+            gene_full: gene_full.then(|| anno::assign::GeneFullIndex::new(anno)),
+            shards: (0..REPLAY_SHARDS).map(|_| Vec::new()).collect(),
+            stats: AssignmentStats::default(),
+        }
     }
 
     pub(crate) fn reserve_assignments(&mut self, expected: usize) {
@@ -4148,42 +4212,77 @@ impl<'a> ReplayRowsAccumulator<'a> {
         }
     }
 
-    fn classify(&self, mols: &[MolRec], s: &mut RowScratch)
-        -> (u64, Vec<Vec<ReplayTuple>>)
-    {
-        let mut shards: Vec<Vec<ReplayTuple>> =
-            (0..REPLAY_SHARDS).map(|_| Vec::new()).collect();
-        let mut n = 0u64;
+    fn classify(
+        &self,
+        mols: &[MolRec],
+        s: &mut RowScratch,
+    ) -> (AssignmentStats, Vec<Vec<ReplayTuple>>) {
+        let mut shards: Vec<Vec<ReplayTuple>> = (0..REPLAY_SHARDS).map(|_| Vec::new()).collect();
+        let mut stats = AssignmentStats::default();
         for m in mols {
+            stats.molecule_records += 1;
+            let mut assigned = false;
             let mut handle = |r: Row| {
-                if row_genes_stranded(
-                    &r, self.x, self.anno, &self.bam2anno, MmMissing::SkipAlt,
-                    self.solo_strand, s,
-                ).is_some() {
+                stats.representative_rows += 1;
+                if row_genes_model(
+                    &r,
+                    self.x,
+                    self.anno,
+                    &self.bam2anno,
+                    MmMissing::SkipAlt,
+                    self.solo_strand,
+                    self.gene_full.as_ref(),
+                    s,
+                )
+                .is_some()
+                {
                     if let [g] = s.genes.as_slice() {
-                        n += 1;
-                        shards[r.cell as usize % REPLAY_SHARDS]
-                            .push((r.cell, r.umi_class, *g, r.weight));
+                        stats.assigned_representative_rows += 1;
+                        assigned = true;
+                        shards[r.cell as usize % REPLAY_SHARDS].push((
+                            r.cell,
+                            r.umi_class,
+                            *g,
+                            r.weight,
+                        ));
                     }
                 }
             };
             for ch in &m.chains {
                 for (pos, shape) in &ch.reps {
-                    handle(Row { cell: m.cell, umi_class: m.umi_class, chrom: m.chrom, pos: *pos,
-                        strand_rev: m.strand_rev, shape: *shape, weight: ch.weight,
-                        pattern: u32::MAX });
+                    handle(Row {
+                        cell: m.cell,
+                        umi_class: m.umi_class,
+                        chrom: m.chrom,
+                        pos: *pos,
+                        strand_rev: m.strand_rev,
+                        shape: *shape,
+                        weight: ch.weight,
+                        pattern: u32::MAX,
+                    });
                 }
             }
             for (pos, shape, pattern, weight) in &m.mms {
-                handle(Row { cell: m.cell, umi_class: m.umi_class, chrom: m.chrom, pos: *pos,
-                    strand_rev: m.strand_rev, shape: *shape, weight: *weight, pattern: *pattern });
+                handle(Row {
+                    cell: m.cell,
+                    umi_class: m.umi_class,
+                    chrom: m.chrom,
+                    pos: *pos,
+                    strand_rev: m.strand_rev,
+                    shape: *shape,
+                    weight: *weight,
+                    pattern: *pattern,
+                });
             }
+            stats.assigned_molecule_records += u64::from(assigned);
         }
-        (n, shards)
+        (stats, shards)
     }
 
-    fn append_parts(&mut self, mut parts: Vec<(u64, Vec<Vec<ReplayTuple>>)>) {
-        self.n_assigned += parts.iter().map(|(n, _)| *n).sum::<u64>();
+    fn append_parts(&mut self, mut parts: Vec<(AssignmentStats, Vec<Vec<ReplayTuple>>)>) {
+        for (stats, _) in &parts {
+            self.stats.add(*stats);
+        }
         for k in 0..REPLAY_SHARDS {
             self.shards[k].reserve(parts.iter().map(|(_, p)| p[k].len()).sum());
         }
@@ -4197,20 +4296,29 @@ impl<'a> ReplayRowsAccumulator<'a> {
     /// Fine reducer tasks let work stealing smooth gene-density differences within the fixed
     /// decode window without concatenating molecule records.
     pub(crate) fn add_archive_chunks(&mut self, chunks: &[Vec<MolRec>]) {
-        let tasks: Vec<&[MolRec]> = chunks.iter()
-            .flat_map(|chunk| chunk.chunks(1 << 16)).collect();
-        let parts: Vec<_> = tasks.into_par_iter()
-            .map_init(RowScratch::default, |s, part| self.classify(part, s)).collect();
+        let tasks: Vec<&[MolRec]> = chunks
+            .iter()
+            .flat_map(|chunk| chunk.chunks(1 << 16))
+            .collect();
+        let parts: Vec<_> = tasks
+            .into_par_iter()
+            .map_init(RowScratch::default, |s, part| self.classify(part, s))
+            .collect();
         self.append_parts(parts);
     }
 
     /// Preserve the original parallel shard assembly for a performance-faithful `--eager` arm.
     fn add_molecules_eager(&mut self, mols: &[MolRec]) {
-        let parts: Vec<_> = mols.par_chunks(1 << 19)
-            .map_init(RowScratch::default, |s, part| self.classify(part, s)).collect();
-        self.n_assigned += parts.iter().map(|(n, _)| *n).sum::<u64>();
+        let parts: Vec<_> = mols
+            .par_chunks(1 << 19)
+            .map_init(RowScratch::default, |s, part| self.classify(part, s))
+            .collect();
+        for (stats, _) in &parts {
+            self.stats.add(*stats);
+        }
         let mut shards: Vec<Vec<ReplayTuple>> = (0..REPLAY_SHARDS)
-            .map(|k| Vec::with_capacity(parts.iter().map(|(_, p)| p[k].len()).sum())).collect();
+            .map(|k| Vec::with_capacity(parts.iter().map(|(_, p)| p[k].len()).sum()))
+            .collect();
         shards.par_iter_mut().enumerate().for_each(|(k, dst)| {
             for (_, worker_shards) in &parts {
                 dst.extend_from_slice(&worker_shards[k]);
@@ -4220,10 +4328,15 @@ impl<'a> ReplayRowsAccumulator<'a> {
     }
 
     pub(crate) fn finish(self) -> (FxHashMap<(u32, u32), u32>, u64, u64) {
+        let (counts, stats, total) = self.finish_with_stats();
+        (counts, stats.assigned_representative_rows, total)
+    }
+
+    pub(crate) fn finish_with_stats(self) -> (FxHashMap<(u32, u32), u32>, AssignmentStats, u64) {
         let Self {
             x,
             shards,
-            n_assigned,
+            mut stats,
             ..
         } = self;
 
@@ -4251,9 +4364,9 @@ impl<'a> ReplayRowsAccumulator<'a> {
         }
         drop(cur);
 
-        let counted: Vec<((u32, u32), u32)> = shards
+        let counted_shards: Vec<_> = shards
             .into_par_iter()
-            .flat_map_iter(|mut shard| {
+            .map(|mut shard| {
                 // Sorting groups (cell, class) runs with genes as sub-runs; weight sums, the
                 // MultiGeneUMI_CR best-gene choice and the per-(cell, gene) collapse all read off
                 // contiguous slices. Semantics identical to the old nested-map pipeline.
@@ -4327,12 +4440,18 @@ impl<'a> ReplayRowsAccumulator<'a> {
                     out.push(((cell, gene), roots));
                     g0 = g1;
                 }
-                out
+                (out, kept.len() as u64)
             })
             .collect();
 
-    let total: u64 = counted.iter().map(|(_, n)| *n as u64).sum();
-    (counted.into_iter().collect(), n_assigned, total)
+        stats.umi_classes = u64::from(x.n_classes);
+        stats.assigned_umi_classes = counted_shards.iter().map(|(_, n)| *n).sum();
+        let counted: FxHashMap<_, _> = counted_shards
+            .into_iter()
+            .flat_map(|(rows, _)| rows)
+            .collect();
+        let total = counted.values().map(|n| u64::from(*n)).sum();
+        (counted, stats, total)
     }
 }
 
@@ -4355,4 +4474,107 @@ pub fn replay_rows_stranded(
     let mut replay = ReplayRowsAccumulator::with_strand(x, anno, solo_strand);
     replay.add_molecules_eager(&x.mols);
     replay.finish()
+}
+
+/// Gene or intron-inclusive GeneFull assignment with the same global UMI collapse.
+pub(crate) fn replay_rows_model(
+    x: &Extracted,
+    anno: &anno::Annotation,
+    solo_strand: anno::assign::SoloStrand,
+    gene_full: bool,
+) -> (FxHashMap<(u32, u32), u32>, AssignmentStats, u64) {
+    let mut replay = ReplayRowsAccumulator::with_model(x, anno, solo_strand, gene_full);
+    replay.add_molecules_eager(&x.mols);
+    replay.finish_with_stats()
+}
+
+#[cfg(test)]
+mod genefull_replay_tests {
+    use super::*;
+
+    #[test]
+    fn genefull_alternatives_global_collapse_and_statistic_units() {
+        let path =
+            std::env::temp_dir().join(format!("gravlax-genefull-{}.gtf", std::process::id()));
+        std::fs::write(
+            &path,
+            concat!(
+                "chr1\tX\texon\t101\t200\t.\t+\t.\tgene_id \"A\"; transcript_id \"A1\";\n",
+                "chr1\tX\texon\t401\t500\t.\t+\t.\tgene_id \"A\"; transcript_id \"A1\";\n",
+                "chr1\tX\texon\t251\t300\t.\t+\t.\tgene_id \"B\"; transcript_id \"B1\";\n"
+            ),
+        )
+        .unwrap();
+        let anno = anno::Annotation::from_gtf(&path).unwrap();
+        std::fs::remove_file(&path).unwrap();
+        let molecule = |class, pos| MolRec {
+            cell: 0,
+            umi_class: class,
+            chrom: 0,
+            strand_rev: false,
+            chains: smallvec::smallvec![MolChain {
+                weight: 2,
+                reps: smallvec::smallvec![(pos, 0)]
+            }],
+            mms: SmallVec::new(),
+        };
+        let mut mols = vec![
+            molecule(0, 210),
+            molecule(1, 210),
+            molecule(0, 410),
+            molecule(2, 260),
+            molecule(3, 210),
+            molecule(4, 210),
+            molecule(5, 210),
+        ];
+        mols[0].chains[0].reps.push((220, 0));
+        for (i, pattern) in [(4, 0), (5, 1)] {
+            mols[i].chains.clear();
+            mols[i].mms.push((210, 0, pattern, 1));
+        }
+        mols[6].chrom = 1; // missing annotation chromosome
+        let alt = |offset| PatAlt {
+            chrom: 0,
+            offset,
+            strand_flip: false,
+            shape: SAME_SHAPE,
+        };
+        let x = Extracted {
+            mols,
+            edges: vec![(0, 1)],
+            cells: vec![0],
+            shapes: vec![Shape {
+                blocks: vec![(0, 20)],
+            }],
+            patterns: vec![vec![alt(0), alt(200)], vec![alt(0), alt(50)]],
+            n_classes: 6,
+            chrom_names: vec!["chr1".into(), "missing".into()],
+        };
+        let (gene, _, gene_total) = replay_rows(&x, &anno);
+        assert_eq!(gene_total, 4);
+        assert_eq!(gene.get(&(0, 0)), Some(&2));
+        assert_eq!(gene.get(&(0, 1)), Some(&2));
+        let (full, stats, total) =
+            replay_rows_model(&x, &anno, anno::assign::SoloStrand::Forward, true);
+        assert_eq!(total, 2);
+        assert_eq!(full, FxHashMap::from_iter([((0, 0), 2)]));
+        assert_eq!(
+            stats,
+            AssignmentStats {
+                molecule_records: 7,
+                assigned_molecule_records: 4,
+                representative_rows: 8,
+                assigned_representative_rows: 5,
+                umi_classes: 6,
+                assigned_umi_classes: 3
+            }
+        );
+        // Related classes and repeated class records cross reducer batch boundaries.
+        let mut streaming =
+            ReplayRowsAccumulator::with_model(&x, &anno, anno::assign::SoloStrand::Forward, true);
+        for m in &x.mols {
+            streaming.add_archive_chunks(&[vec![m.clone()]]);
+        }
+        assert_eq!(streaming.finish_with_stats(), (full, stats, total));
+    }
 }

--- a/crates/aie/tests/cli_golden.rs
+++ b/crates/aie/tests/cli_golden.rs
@@ -455,6 +455,84 @@ fn bam_archive_and_post_correction_bam_replays_match() {
         "packed and eager EM summaries differ"
     );
 
+    let full_gtf = scratch.0.join("genefull-intronic.gtf");
+    std::fs::write(
+        &full_gtf,
+        concat!(
+            "chr1\ttest\texon\t1\t20\t.\t+\t.\tgene_id \"G1\"; transcript_id \"T1\";\n",
+            "chr1\ttest\texon\t1999900\t2000000\t.\t+\t.\tgene_id \"G1\"; transcript_id \"T1\";\n",
+        ),
+    )
+    .unwrap();
+    let full_metrics = scratch.0.join("genefull-em-metrics.json");
+    let mut full_em = Command::new(bin);
+    full_em
+        .arg("em")
+        .arg(&archive)
+        .arg("--gtf")
+        .arg(&full_gtf)
+        .arg("--gene-full")
+        .arg("--mask")
+        .arg("0")
+        .arg("--metrics-json")
+        .arg(&full_metrics);
+    let full_em = run(full_em);
+    assert_eq!(full_em.stdout, packed_em.stdout);
+    let full_metrics: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(full_metrics).unwrap()).unwrap();
+    assert_eq!(full_metrics["counting_model"], "GeneFull");
+    assert!(
+        full_metrics["evaluation_counts"]["all_input_single_gene_classes"]
+            .as_u64()
+            .unwrap()
+            > 0
+    );
+    let intronic_gene_metrics = scratch.0.join("intronic-gene-em.json");
+    let mut intronic_gene = Command::new(bin);
+    intronic_gene
+        .arg("em")
+        .arg(&archive)
+        .arg("--gtf")
+        .arg(&full_gtf)
+        .arg("--mask")
+        .arg("0")
+        .arg("--metrics-json")
+        .arg(&intronic_gene_metrics);
+    run(intronic_gene);
+    let intronic_gene_metrics: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(intronic_gene_metrics).unwrap()).unwrap();
+    assert_eq!(
+        intronic_gene_metrics["evaluation_counts"]["all_input_single_gene_classes"],
+        0
+    );
+
+    assert_eq!(
+        full_metrics["evaluation_counts"]["unit"],
+        "UMI classes before one-mismatch collapse"
+    );
+    let mut full_eager = Command::new(bin);
+    full_eager
+        .arg("em")
+        .arg(&archive)
+        .arg("--gtf")
+        .arg(&full_gtf)
+        .arg("--gene-full")
+        .arg("--mask")
+        .arg("0")
+        .arg("--eager");
+    assert_eq!(run(full_eager).stdout, full_em.stdout);
+    let incompatible = Command::new(bin)
+        .arg("em")
+        .arg(&archive)
+        .arg("--gtf")
+        .arg(&full_gtf)
+        .arg("--gene-full")
+        .arg("--star")
+        .output()
+        .unwrap();
+    assert!(!incompatible.status.success());
+    assert!(String::from_utf8_lossy(&incompatible.stderr).contains("cannot be used with"));
+
     let groups = scratch.0.join("groups.tsv");
     let metrics = scratch.0.join("hierarchical-metrics.json");
     let candidates = scratch.0.join("candidate-genes.txt");

--- a/crates/aie/tests/cli_golden.rs
+++ b/crates/aie/tests/cli_golden.rs
@@ -521,17 +521,6 @@ fn bam_archive_and_post_correction_bam_replays_match() {
         .arg("0")
         .arg("--eager");
     assert_eq!(run(full_eager).stdout, full_em.stdout);
-    let incompatible = Command::new(bin)
-        .arg("em")
-        .arg(&archive)
-        .arg("--gtf")
-        .arg(&full_gtf)
-        .arg("--gene-full")
-        .arg("--star")
-        .output()
-        .unwrap();
-    assert!(!incompatible.status.success());
-    assert!(String::from_utf8_lossy(&incompatible.stderr).contains("cannot be used with"));
 
     let groups = scratch.0.join("groups.tsv");
     let metrics = scratch.0.join("hierarchical-metrics.json");
@@ -928,6 +917,152 @@ fn bam_archive_and_post_correction_bam_replays_match() {
             assert_eq!(forward, std::fs::read(out.join(name)).unwrap(),
                 "{name} differs under reverse-strand replay through {}", out.display());
         }
+    }
+}
+
+#[test]
+fn em_scoring_selection_modes_and_spill_preserve_inference() {
+    let scratch = Scratch::new();
+    let bam = scratch.0.join("em.bam");
+    let archive = scratch.0.join("em.aie");
+    let whitelist = scratch.0.join("barcodes.tsv");
+    let selected = scratch.0.join("selected.tsv");
+    let groups = scratch.0.join("groups.tsv");
+    let gtf = scratch.0.join("em.gtf");
+    std::fs::write(&whitelist, format!("{BARCODE}\n{SECOND_BARCODE}\n")).unwrap();
+    std::fs::write(&selected, format!("{SECOND_BARCODE}-1\n")).unwrap();
+    std::fs::write(&groups, format!("{SECOND_BARCODE}\tfixed\n")).unwrap();
+    std::fs::write(
+        &gtf,
+        concat!(
+            "chr1\tX\texon\t101\t200\t.\t+\t.\tgene_id \"A\"; transcript_id \"A\";\n",
+            "chr1\tX\texon\t401\t500\t.\t+\t.\tgene_id \"A\"; transcript_id \"A\";\n",
+            "chr1\tX\texon\t251\t300\t.\t+\t.\tgene_id \"B\"; transcript_id \"B\";\n",
+        ),
+    )
+    .unwrap();
+    let header = sam::Header::builder()
+        .add_reference_sequence(
+            "chr1",
+            Map::<ReferenceSequence>::new(NonZero::new(2_000_000).unwrap()),
+        )
+        .build();
+    let mut writer = bam::io::Writer::new(std::fs::File::create(&bam).unwrap());
+    writer.write_header(&header).unwrap();
+    for start in [201, 251] {
+        for barcode in [BARCODE, SECOND_BARCODE] {
+            writer
+                .write_alignment_record(
+                    &header,
+                    &tagged_record_for_barcode(
+                        &format!("{barcode}-{start}"),
+                        start,
+                        "AAAAAAAAAAAA",
+                        Flags::empty(),
+                        1,
+                        barcode,
+                    ),
+                )
+                .unwrap();
+        }
+    }
+    writer.try_finish().unwrap();
+    let bin = env!("CARGO_BIN_EXE_aie");
+    let mut ingest = Command::new(bin);
+    ingest
+        .arg("ingest-archive")
+        .arg(&bam)
+        .arg("--whitelist")
+        .arg(&whitelist)
+        .arg("--out")
+        .arg(&archive);
+    run(ingest);
+    let base = || {
+        let mut cmd = Command::new(bin);
+        cmd.arg("dev")
+            .arg("em")
+            .arg(&archive)
+            .arg("--gtf")
+            .arg(&gtf)
+            .args(["--gene-full", "--mask", "1"]);
+        cmd
+    };
+    let mut results = Vec::new();
+    for (name, grouped, mode, spill) in [
+        ("legacy-groups", true, None, false),
+        ("scored", false, None, false),
+        ("pooled", false, Some("pooled"), false),
+        ("spilled", false, Some("pooled"), true),
+        ("paired", true, Some("convex,pooled"), false),
+    ] {
+        let metrics = scratch.0.join(format!("{name}.json"));
+        let mut cmd = base();
+        cmd.arg("--metrics-json").arg(&metrics);
+        if grouped {
+            cmd.arg("--groups").arg(&groups);
+        } else {
+            cmd.arg("--eval-barcodes").arg(&selected);
+        }
+        if let Some(mode) = mode {
+            cmd.args(["--modes", mode]);
+        }
+        if spill {
+            cmd.args(["--support-memory-mib", "0"]);
+        }
+        run(cmd);
+        let result: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(metrics).unwrap()).unwrap();
+        assert_eq!(result["scored_cells"], 1);
+        assert_eq!(result["evaluation_counts"]["all_input_masked_classes"], 2);
+        assert_eq!(
+            result["evaluation_counts"]["scored_population_evaluable_classes"],
+            1
+        );
+        assert_eq!(result["support_storage"]["spilled"], spill);
+        results.push(result);
+    }
+    let pooled = |v: &serde_json::Value| {
+        v["modes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|m| m["name"] == "pooled")
+            .unwrap()
+            .clone()
+    };
+    for result in &results[1..] {
+        assert_eq!(pooled(result), pooled(&results[0]));
+    }
+    assert_eq!(results[0]["modes"].as_array().unwrap().len(), 9);
+    assert_eq!(results[1]["modes"].as_array().unwrap().len(), 4);
+    assert_eq!(results[2]["modes"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        results[4]["paired_comparisons"].as_array().unwrap().len(),
+        1
+    );
+    for flags in [
+        vec!["--modes", "group"],
+        vec!["--modes", "pooled,pooled"],
+        vec!["--solo-strand", "invalid"],
+        vec!["--star", "--modes", "pooled"],
+        vec!["--eager", "--modes", "pooled"],
+    ] {
+        assert!(!base().args(flags).output().unwrap().status.success());
+    }
+    for text in [
+        "",
+        "invalid\n",
+        "TTTTTTTTTTTTTTTT\n",
+        &format!("{BARCODE}\n{BARCODE}-1\n"),
+    ] {
+        std::fs::write(&selected, text).unwrap();
+        assert!(!base()
+            .arg("--eval-barcodes")
+            .arg(&selected)
+            .output()
+            .unwrap()
+            .status
+            .success());
     }
 }
 

--- a/crates/anno/examples/genefull_index_benchmark.rs
+++ b/crates/anno/examples/genefull_index_benchmark.rs
@@ -1,0 +1,200 @@
+//! Isolate the former mixed-strand placement lookup against direct block/strand lookup.
+//! cargo run --release -p gravlax-anno --example genefull_index_benchmark -- annotation.aic
+//! Deterministic gene-local queries; does not measure archive decoding or EM iterations.
+use anno::assign::{GeneFullIndex, SoloStrand};
+use evidence_io::{Block, Junction, Placement, Strand};
+use std::{hint::black_box, time::Instant};
+
+struct Span {
+    start: u32,
+    end: u32,
+    max_end: u32,
+    gene: u32,
+    reverse: bool,
+}
+
+fn reference_index(annotation: &anno::Annotation) -> hashbrown::HashMap<u32, Vec<Span>> {
+    let mut bounds = hashbrown::HashMap::<(u32, u32, bool), (u32, u32)>::new();
+    for t in &annotation.transcripts {
+        let (start, end) = t.span();
+        if start >= end {
+            continue;
+        }
+        let entry = bounds
+            .entry((t.chrom, t.gene, t.strand_rev))
+            .or_insert((start, end));
+        entry.0 = entry.0.min(start);
+        entry.1 = entry.1.max(end);
+    }
+    let mut chroms: hashbrown::HashMap<u32, Vec<Span>> = hashbrown::HashMap::new();
+    for ((chrom, gene, reverse), (start, end)) in bounds {
+        chroms.entry(chrom).or_default().push(Span {
+            start,
+            end,
+            max_end: 0,
+            gene,
+            reverse,
+        });
+    }
+    for spans in chroms.values_mut() {
+        spans.sort_unstable_by_key(|s| (s.start, s.end, s.gene, s.reverse));
+        let mut max_end = 0;
+        for span in spans {
+            max_end = max_end.max(span.end);
+            span.max_end = max_end;
+        }
+    }
+    chroms
+}
+
+fn reference_query(
+    index: &hashbrown::HashMap<u32, Vec<Span>>,
+    p: &Placement,
+    strand: SoloStrand,
+    out: &mut Vec<u32>,
+) {
+    out.clear();
+    if let Some(spans) = index.get(&p.chrom) {
+        for b in &p.blocks {
+            if b.start >= b.end {
+                continue;
+            }
+            let hi = spans.partition_point(|s| s.start < b.end);
+            for span in spans[..hi].iter().rev() {
+                if span.max_end <= b.start {
+                    break;
+                }
+                if span.end > b.start
+                    && strand.accepts(matches!(p.strand, Strand::Reverse), span.reverse)
+                {
+                    out.push(span.gene);
+                }
+            }
+        }
+    }
+    out.sort_unstable();
+    out.dedup();
+}
+
+fn main() -> anyhow::Result<()> {
+    let path = std::env::args_os().nth(1).expect("annotation path");
+    let annotation = anno::Annotation::from_path(std::path::Path::new(&path))?;
+    anyhow::ensure!(
+        !annotation.transcripts.is_empty(),
+        "annotation has no transcripts"
+    );
+    let old = reference_index(&annotation);
+    let new = GeneFullIndex::new(&annotation);
+    let mut seed = 2718u64;
+    let mut random = || {
+        seed = seed.wrapping_mul(6364136223846793005).wrapping_add(1);
+        (seed >> 32) as u32
+    };
+    let queries: Vec<_> = (0..200_000)
+        .map(|_| {
+            let t = &annotation.transcripts[random() as usize % annotation.transcripts.len()];
+            let (start, end) = t.span();
+            let pos = start + random() % (end - start).max(1);
+            (t.chrom, random() % 2 == 0, pos, random() % 2 == 0)
+        })
+        .collect();
+    let mut placement = Placement {
+        chrom: 0,
+        strand: Strand::Forward,
+        blocks: Vec::new(),
+        junctions: Vec::new(),
+        nm: 0,
+        score: 0,
+        nh: 1,
+        clip: (0, 0),
+    };
+    let mut observed = Vec::new();
+    let mut expected = Vec::new();
+    println!("strand\trepetition\timplementation\tqueries\tseconds\tgene_hits");
+    for strand in [
+        SoloStrand::Forward,
+        SoloStrand::Reverse,
+        SoloStrand::Unstranded,
+    ] {
+        // Check every query before timing; use direct reconstruction as the reference.
+        for &(chrom, reverse, pos, spliced) in &queries {
+            let blocks = [(pos, pos + 50), (pos + 150, pos + 200)];
+            let blocks = &blocks[..if spliced { 2 } else { 1 }];
+            placement.chrom = chrom;
+            placement.strand = if reverse {
+                Strand::Reverse
+            } else {
+                Strand::Forward
+            };
+            placement.blocks.clear();
+            placement
+                .blocks
+                .extend(blocks.iter().map(|&(start, end)| Block { start, end }));
+            reference_query(&old, &placement, strand, &mut expected);
+            new.genes_for_blocks_into(
+                chrom,
+                reverse,
+                strand,
+                blocks.iter().copied(),
+                &mut observed,
+            );
+            assert_eq!(observed, expected);
+        }
+        for rep in 0..3 {
+            for optimized in if rep % 2 == 0 {
+                [false, true]
+            } else {
+                [true, false]
+            } {
+                let start = Instant::now();
+                let mut hits = 0usize;
+                for _ in 0..5 {
+                    for &(chrom, reverse, pos, spliced) in &queries {
+                        let blocks = [(pos, pos + 50), (pos + 150, pos + 200)];
+                        let blocks = &blocks[..if spliced { 2 } else { 1 }];
+                        if optimized {
+                            new.genes_for_blocks_into(
+                                chrom,
+                                reverse,
+                                strand,
+                                blocks.iter().copied(),
+                                &mut observed,
+                            );
+                        } else {
+                            placement.chrom = chrom;
+                            placement.strand = if reverse {
+                                Strand::Reverse
+                            } else {
+                                Strand::Forward
+                            };
+                            placement.blocks.clear();
+                            placement
+                                .blocks
+                                .extend(blocks.iter().map(|&(start, end)| Block { start, end }));
+                            placement.junctions.clear();
+                            placement
+                                .junctions
+                                .extend(blocks.windows(2).map(|w| Junction {
+                                    donor: w[0].1,
+                                    acceptor: w[1].0,
+                                }));
+                            reference_query(&old, &placement, strand, &mut observed);
+                        }
+                        hits += black_box(&observed).len();
+                    }
+                }
+                println!(
+                    "{strand:?}\t{rep}\t{}\t{}\t{:.6}\t{hits}",
+                    if optimized {
+                        "direct-strand-index"
+                    } else {
+                        "placement-mixed-index"
+                    },
+                    queries.len() * 5,
+                    start.elapsed().as_secs_f64()
+                );
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/anno/src/assign.rs
+++ b/crates/anno/src/assign.rs
@@ -41,6 +41,82 @@ impl SoloStrand {
     }
 }
 
+/// STARsolo `GeneFull`: overlap aligned blocks with exon-derived full gene spans.
+/// Built once per replay; the archive and compiled annotation formats are unchanged.
+pub struct GeneFullIndex {
+    chroms: hashbrown::HashMap<u32, Vec<GeneSpan>>,
+}
+
+struct GeneSpan {
+    start: u32,
+    end: u32,
+    max_end: u32,
+    gene: u32,
+    reverse: bool,
+}
+
+impl GeneFullIndex {
+    pub fn new(anno: &crate::Annotation) -> Self {
+        let mut bounds = hashbrown::HashMap::<(u32, u32, bool), (u32, u32)>::new();
+        for t in &anno.transcripts {
+            let (start, end) = t.span();
+            if start >= end {
+                continue;
+            }
+            let entry = bounds
+                .entry((t.chrom, t.gene, t.strand_rev))
+                .or_insert((start, end));
+            entry.0 = entry.0.min(start);
+            entry.1 = entry.1.max(end);
+        }
+        let mut chroms: hashbrown::HashMap<u32, Vec<GeneSpan>> = hashbrown::HashMap::new();
+        for ((chrom, gene, reverse), (start, end)) in bounds {
+            chroms.entry(chrom).or_default().push(GeneSpan {
+                start,
+                end,
+                max_end: 0,
+                gene,
+                reverse,
+            });
+        }
+        for spans in chroms.values_mut() {
+            spans.sort_unstable_by_key(|s| (s.start, s.end, s.gene, s.reverse));
+            let mut max_end = 0;
+            for span in spans {
+                max_end = max_end.max(span.end);
+                span.max_end = max_end;
+            }
+        }
+        Self { chroms }
+    }
+
+    /// Only aligned blocks overlap: genes inside skipped introns are not hit by
+    /// the outer alignment span alone. Junction concordance is not required.
+    pub fn genes_into(&self, p: &Placement, chrom: u32, strand: SoloStrand, out: &mut Vec<u32>) {
+        out.clear();
+        let Some(spans) = self.chroms.get(&chrom) else {
+            return;
+        };
+        let reverse = matches!(p.strand, evidence_io::Strand::Reverse);
+        for block in &p.blocks {
+            if block.start >= block.end {
+                continue;
+            }
+            let hi = spans.partition_point(|s| s.start < block.end);
+            for span in spans[..hi].iter().rev() {
+                if span.max_end <= block.start {
+                    break;
+                }
+                if span.end > block.start && strand.accepts(reverse, span.reverse) {
+                    out.push(span.gene);
+                }
+            }
+        }
+        out.sort_unstable();
+        out.dedup();
+    }
+}
+
 /// STAR's `AlignVsTranscript` states, minus the transcript-distance bookkeeping replay never uses.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Vs {
@@ -430,4 +506,165 @@ mod tests {
         assert!(Unstranded.accepts(true, true));
     }
 
+}
+
+#[cfg(test)]
+mod genefull_tests {
+    use super::*;
+    use crate::{Annotation, Exon};
+    use evidence_io::{Block, Strand};
+
+    fn annotation(transcripts: Vec<Transcript>) -> Annotation {
+        Annotation {
+            gene_ids: Vec::new(),
+            gene_names: Vec::new(),
+            transcript_ids: Vec::new(),
+            source_exons: Vec::new(),
+            chrom_ids: Default::default(),
+            index: crate::build_index(&transcripts),
+            transcripts,
+        }
+    }
+
+    fn tx(gene: u32, chrom: u32, reverse: bool, exons: &[(u32, u32)]) -> Transcript {
+        Transcript {
+            gene,
+            chrom,
+            strand_rev: reverse,
+            exons: exons
+                .iter()
+                .map(|&(start, end)| Exon { start, end })
+                .collect(),
+        }
+    }
+
+    fn placement(blocks: &[(u32, u32)], reverse: bool) -> Placement {
+        Placement {
+            chrom: 99,
+            strand: if reverse {
+                Strand::Reverse
+            } else {
+                Strand::Forward
+            },
+            blocks: blocks
+                .iter()
+                .map(|&(start, end)| Block { start, end })
+                .collect(),
+            junctions: Vec::new(),
+            nm: 0,
+            score: 0,
+            nh: 1,
+            clip: (0, 0),
+        }
+    }
+
+    #[test]
+    fn genefull_boundaries_isoforms_nested_genes_and_skipped_introns() {
+        let a = annotation(vec![
+            tx(0, 0, false, &[(100, 200), (400, 500)]),
+            tx(0, 0, false, &[(700, 800)]),
+            tx(1, 0, false, &[(250, 300)]),
+            tx(2, 0, true, &[(100, 800)]),
+            tx(0, 1, false, &[(900, 1000)]),
+            tx(0, 0, true, &[(900, 1000)]),
+        ]);
+        let index = GeneFullIndex::new(&a);
+        for (blocks, strand, expected) in [
+            (vec![(99, 100)], SoloStrand::Forward, vec![]),
+            (vec![(100, 101)], SoloStrand::Forward, vec![0]),
+            (vec![(799, 800)], SoloStrand::Forward, vec![0]),
+            (vec![(800, 801)], SoloStrand::Forward, vec![]),
+            (vec![(600, 650)], SoloStrand::Forward, vec![0]), // gap between isoforms
+            (vec![(260, 270)], SoloStrand::Forward, vec![0, 1]),
+            (vec![(150, 200), (400, 450)], SoloStrand::Forward, vec![0]),
+            (vec![(150, 190), (410, 450)], SoloStrand::Forward, vec![0]), // novel splice
+            (vec![(100, 110)], SoloStrand::Reverse, vec![2]),
+            (vec![(100, 110)], SoloStrand::Unstranded, vec![0, 2]),
+            (vec![(950, 960)], SoloStrand::Forward, vec![]), // no cross-strand union
+            (vec![(200, 200)], SoloStrand::Unstranded, vec![]),
+        ] {
+            let mut got = vec![999];
+            index.genes_into(&placement(&blocks, false), 0, strand, &mut got);
+            assert_eq!(got, expected, "{blocks:?} {strand:?}");
+        }
+        let mut got = Vec::new();
+        index.genes_into(
+            &placement(&[(950, 960)], false),
+            1,
+            SoloStrand::Forward,
+            &mut got,
+        );
+        assert_eq!(got, vec![0]);
+        index.genes_into(
+            &placement(&[(950, 960)], false),
+            2,
+            SoloStrand::Forward,
+            &mut got,
+        );
+        assert!(got.is_empty());
+    }
+
+    #[test]
+    fn genefull_index_matches_independent_exhaustive_overlap() {
+        let mut seed = 421u64;
+        let mut random = || {
+            seed = seed.wrapping_mul(6364136223846793005).wrapping_add(1);
+            (seed >> 32) as u32
+        };
+        let transcripts = (0..300)
+            .map(|_| {
+                let start = random() % 2000;
+                tx(
+                    random() % 30,
+                    random() % 4,
+                    random() % 2 == 0,
+                    &[
+                        (start, start + 1 + random() % 30),
+                        (start + 50, start + 100),
+                    ],
+                )
+            })
+            .collect();
+        let a = annotation(transcripts);
+        let index = GeneFullIndex::new(&a);
+        // Oracle scans every exon to derive bounds, then every gene; no interval index.
+        let mut spans = std::collections::BTreeMap::<(u32, u32, bool), (u32, u32)>::new();
+        for t in &a.transcripts {
+            for exon in &t.exons {
+                let span = spans
+                    .entry((t.gene, t.chrom, t.strand_rev))
+                    .or_insert((u32::MAX, 0));
+                span.0 = span.0.min(exon.start);
+                span.1 = span.1.max(exon.end);
+            }
+        }
+        for _ in 0..2000 {
+            let start = random() % 2500;
+            let p = placement(
+                &[(start, start + random() % 100), (start + 150, start + 200)],
+                random() % 2 == 0,
+            );
+            let chrom = random() % 5;
+            for strand in [
+                SoloStrand::Forward,
+                SoloStrand::Reverse,
+                SoloStrand::Unstranded,
+            ] {
+                let mut expected = std::collections::BTreeSet::new();
+                for (&(gene, c, reverse), &(s, e)) in &spans {
+                    if c == chrom
+                        && strand.accepts(matches!(p.strand, Strand::Reverse), reverse)
+                        && p.blocks
+                            .iter()
+                            .any(|b| b.start < b.end && b.start < e && s < b.end)
+                    {
+                        expected.insert(gene);
+                    }
+                }
+                let mut got = Vec::new();
+                index.genes_into(&p, chrom, strand, &mut got);
+                assert_eq!(got, expected.into_iter().collect::<Vec<_>>());
+            }
+        }
+    }
 }

--- a/crates/anno/src/assign.rs
+++ b/crates/anno/src/assign.rs
@@ -44,7 +44,7 @@ impl SoloStrand {
 /// STARsolo `GeneFull`: overlap aligned blocks with exon-derived full gene spans.
 /// Built once per replay; the archive and compiled annotation formats are unchanged.
 pub struct GeneFullIndex {
-    chroms: hashbrown::HashMap<u32, Vec<GeneSpan>>,
+    chroms: hashbrown::HashMap<u32, [Vec<GeneSpan>; 2]>,
 }
 
 struct GeneSpan {
@@ -52,7 +52,6 @@ struct GeneSpan {
     end: u32,
     max_end: u32,
     gene: u32,
-    reverse: bool,
 }
 
 impl GeneFullIndex {
@@ -69,22 +68,23 @@ impl GeneFullIndex {
             entry.0 = entry.0.min(start);
             entry.1 = entry.1.max(end);
         }
-        let mut chroms: hashbrown::HashMap<u32, Vec<GeneSpan>> = hashbrown::HashMap::new();
+        let mut chroms: hashbrown::HashMap<u32, [Vec<GeneSpan>; 2]> = hashbrown::HashMap::new();
         for ((chrom, gene, reverse), (start, end)) in bounds {
-            chroms.entry(chrom).or_default().push(GeneSpan {
+            chroms.entry(chrom).or_default()[usize::from(reverse)].push(GeneSpan {
                 start,
                 end,
                 max_end: 0,
                 gene,
-                reverse,
             });
         }
-        for spans in chroms.values_mut() {
-            spans.sort_unstable_by_key(|s| (s.start, s.end, s.gene, s.reverse));
-            let mut max_end = 0;
-            for span in spans {
-                max_end = max_end.max(span.end);
-                span.max_end = max_end;
+        for strands in chroms.values_mut() {
+            for spans in strands {
+                spans.sort_unstable_by_key(|s| (s.start, s.end, s.gene));
+                let mut max_end = 0;
+                for span in spans {
+                    max_end = max_end.max(span.end);
+                    span.max_end = max_end;
+                }
             }
         }
         Self { chroms }
@@ -93,22 +93,52 @@ impl GeneFullIndex {
     /// Only aligned blocks overlap: genes inside skipped introns are not hit by
     /// the outer alignment span alone. Junction concordance is not required.
     pub fn genes_into(&self, p: &Placement, chrom: u32, strand: SoloStrand, out: &mut Vec<u32>) {
+        self.genes_for_blocks_into(
+            chrom,
+            matches!(p.strand, evidence_io::Strand::Reverse),
+            strand,
+            p.blocks.iter().map(|b| (b.start, b.end)),
+            out,
+        );
+    }
+
+    /// Query blocks directly from retained shape offsets without materializing a Placement or
+    /// its unused splice junctions. Strand-specific indexes avoid scanning opposite-strand genes.
+    /// Coordinates are zero-based, half-open; output is a sorted, deduplicated gene set.
+    pub fn genes_for_blocks_into(
+        &self,
+        chrom: u32,
+        alignment_reverse: bool,
+        strand: SoloStrand,
+        blocks: impl IntoIterator<Item = (u32, u32)>,
+        out: &mut Vec<u32>,
+    ) {
         out.clear();
-        let Some(spans) = self.chroms.get(&chrom) else {
+        let Some(strands) = self.chroms.get(&chrom) else {
             return;
         };
-        let reverse = matches!(p.strand, evidence_io::Strand::Reverse);
-        for block in &p.blocks {
-            if block.start >= block.end {
+        let indexes: &[Vec<GeneSpan>] = match strand {
+            SoloStrand::Forward => {
+                &strands[usize::from(alignment_reverse)..=usize::from(alignment_reverse)]
+            }
+            SoloStrand::Reverse => {
+                &strands[usize::from(!alignment_reverse)..=usize::from(!alignment_reverse)]
+            }
+            SoloStrand::Unstranded => strands,
+        };
+        for (start, end) in blocks {
+            if start >= end {
                 continue;
             }
-            let hi = spans.partition_point(|s| s.start < block.end);
-            for span in spans[..hi].iter().rev() {
-                if span.max_end <= block.start {
-                    break;
-                }
-                if span.end > block.start && strand.accepts(reverse, span.reverse) {
-                    out.push(span.gene);
+            for spans in indexes {
+                let hi = spans.partition_point(|s| s.start < end);
+                for span in spans[..hi].iter().rev() {
+                    if span.max_end <= start {
+                        break;
+                    }
+                    if span.end > start {
+                        out.push(span.gene);
+                    }
                 }
             }
         }

--- a/docs/genefull-em-strands-optimization.md
+++ b/docs/genefull-em-strands-optimization.md
@@ -1,0 +1,169 @@
+# GeneFull EM strands and optimization validation
+
+This follow-up extends the implementation validated in `genefull-em-validation.md`.
+The original manuscript results and input archives were preserved. Host:
+`nomad00.umiacs.umd.edu`; Rust 1.89.0; STAR 2.7.11b. The baseline source is
+`7078074` on `codex/genefull-replay`.
+
+## Counting models and strand policies
+
+`aie dev em --solo-strand forward|reverse|unstranded` now applies to packed
+recovery EM, its eager reference, and STAR-style EM. `--gene-full --star` is
+supported. Both the unique-count baseline and the ambiguous candidate sets use
+the requested counting model and strand. Forward remains the default; it means
+the cDNA alignment and gene have the same strand, including genes on the minus
+strand. Reverse means opposite strands, and unstranded accepts both.
+
+No archive or compiled-annotation format change is required. The biological
+experiment reads the existing v1 `d2p.aie` archive directly. The GeneFull index
+is derived from the annotation supplied at query time.
+
+## Independent STARsolo comparison
+
+`scripts/validate-em-strands.py` creates synthetic reads containing intronic,
+nested-gene, antisense and genuine multiple-placement evidence. Each of the six
+Gene/GeneFull × strand combinations compares the STAR-style EM contribution
+against STARsolo on the same alignments, checks counting-model/strand metadata,
+compares packed and eager unmasked pooled emission, and verifies that selecting
+only pooled EM reproduces its complete-evaluation metrics and coverage counts.
+
+All six combinations passed. The largest per-entry difference in the EM
+increment was 0.000004 counts, within the programs' different text-output
+rounding. Complete GeneFull unique-plus-EM matrices agreed within 0.000003 counts.
+
+The Gene fixture deliberately includes equal unique-gene support for a UMI.
+Existing replay keeps the lower gene id while STARsolo removes that UMI. This
+produces one extra A count under forward or reverse assignment, and two under
+unstranded assignment. The test reports this separately and checks the EM
+increment independently; it does not label the complete Gene matrices identical.
+No default Gene UMI-filtering or tie-breaking rule was changed. These synthetic
+agreements do not establish universal equivalence after archive representation
+or UMI-collapse differences on arbitrary input.
+
+Rust tests additionally check strand-flipped alternative placements, missing
+annotation contigs, reverse-orientation symmetry, unique-plus-ambiguous classes,
+and STAR's finite convergence threshold. The GeneFull interval index is checked
+against an exhaustive exon-bound overlap oracle for 6,000 query/strand cases.
+
+## Scoring scope, mode selection and memory
+
+`--eval-barcodes` sets the evaluation population independently of group
+assignments. It neither removes other archive barcodes from prior fitting nor
+enables extra inference models. If supplied with `--groups`, it overrides only
+the scored population. `--modes` selects a subset of the existing nine modes,
+retaining canonical execution order and the same ten updates. Paired metrics
+are produced only when both participating modes are selected. Production
+emission still uses pooled EM, which must be included in an explicit mode list.
+
+`--support-memory-mib` defaults to 512 MiB and limits the retained compact
+support arrays. Actual support volume triggers a switch to temporary shards;
+zero forces spilling. It is not a whole-process memory cap: decoded batches,
+worker buffers, spill buffers and the final packed EM state are additional
+working sets. Tests force a switch partway through classes split across batches,
+including deliberately underestimated input-record counts. Every packed field
+matches the in-memory path, and temporary shards are removed after completion.
+
+Metrics record the counting model, strand, evaluation-barcode source, requested
+modes and support-storage scope. Their accuracy denominator remains evaluable
+raw UMI classes before one-mismatch collapse. Replay matrices count collapsed
+UMIs; STAR-style matrices add fractional multi-only raw-class counts to the
+unique replay baseline.
+
+## Brain benchmark protocol
+
+`scripts/benchmark-genefull-em.py` runs three interleaved repetitions with 16
+Rayon threads. The archive receives a read-through warmup. It records elapsed
+time, user/system CPU time, peak process RSS, commands and binary checksums.
+Intermediate binaries isolate mode selection, actual-support spilling, and the
+direct block/strand index. Comparisons verify all selected metrics and coverage
+counts against the nine-mode baseline, and all three replay MEX files by SHA-256.
+
+EM scores the same 6,460 original Gene-called nuclei. Its pooled prior still
+uses every archive barcode after masking. Replay emits the full raw barcode
+list. All runs use the same archived alignments and v49 compiled annotation.
+No nucleus-calling change is part of this benchmark.
+
+The fixed-nucleus denominator is unchanged: 231,351 masked classes, including
+74,467 truth-lost exclusions and 156,884 evaluable classes. This preserves the
+manuscript's conditional pooled accuracy of 74.8999% and all its other shared
+EM metrics. Existing matrix results are preserved separately from the new runs.
+
+## Complete-command results
+
+Medians of three interleaved repetitions; peak RSS is the peak of the complete
+process, expressed in GiB (2^30 bytes). Every result equality gate passed.
+
+| Configuration | Elapsed seconds | Peak RSS, GiB |
+|---|---:|---:|
+| Previous implementation, nine modes | 65.60 | 2.769 |
+| Updated implementation, nine modes | 62.87 | 2.897 |
+| Four modes, previous overlap/spill implementation | 32.46 | 2.741 |
+| Four modes, actual-support spilling | 32.03 | 2.936 |
+| Four modes, actual-support spilling and direct strand index | 32.83 | 2.861 |
+| Updated implementation, pooled only | 23.24 | 2.890 |
+| Previous GeneFull replay | 8.05 | 5.171 |
+| Updated GeneFull replay | 7.95 | 5.184 |
+
+Selecting the four manuscript models reduces elapsed time by 50.0% relative to
+running all nine models in the previous implementation (2.00-fold throughput).
+Selecting only pooled reduces elapsed time by 64.6% (2.82-fold throughput).
+These comparisons explicitly change the amount of requested work; each retained
+model's scientific result is identical. The same nine-mode workload is 4.2%
+faster in these runs.
+
+Actual-support spilling adds a measured peak-memory cost on this brain archive:
+with four modes, the median rises from 2.741 to 2.936 GiB before the lookup change.
+It enforces a candidate-volume budget when the number of candidates per archive
+record is underestimated; it should not be described as a demonstrated reduction
+in whole-process memory. The measured peak retained support capacity before
+spilling was 529,997,216 bytes, within the 536,870,912-byte default budget.
+
+The overlap-index change did not demonstrate a consistent whole-EM speedup:
+four-mode medians were 32.03 seconds before and 32.83 seconds after. Replay
+medians were 8.05 and 7.95 seconds, with overlapping individual timing ranges.
+These small differences should not support a broad throughput claim.
+
+## Isolated overlap lookup
+
+The `gravlax-anno` example `genefull_index_benchmark` checks 200,000 deterministic
+gene-local block queries per strand against the previous mixed-strand index.
+It then interleaves three repetitions of 1,000,000 queries per implementation
+and strand, including single-block and spliced geometries. Every candidate set
+agrees; timings exclude annotation parsing, archive decoding, and EM updates.
+
+| Strand policy | Previous lookup, seconds | Direct strand lookup, seconds | Speed ratio |
+|---|---:|---:|---:|
+| Forward | 0.0822 | 0.0466 | 1.77× |
+| Reverse | 0.0825 | 0.0466 | 1.77× |
+| Unstranded | 0.0762 | 0.0774 | 0.98× |
+
+The index change is retained for its measured strand-specific lookup saving and
+smaller per-gene index entries. It does not establish a material whole-EM speedup.
+
+## Final checks and preserved results
+
+The final Rust workspace suite passed 459 tests with three pre-existing ignored
+tests. Clippy passed for all workspace targets with warnings denied. The 32-page
+documentation site built successfully using Node 22.23.2. Changed Rust regions
+were formatted, and `git diff --check` passed; unrelated historical formatting
+was left intact.
+
+A final binary rerun preserves all nine default Gene EM metric records, paired
+comparisons and coverage counters exactly against the saved manuscript control.
+Default Gene replay preserves all three raw MEX files byte-for-byte. The legacy
+forward-strand Gene STAR-style fixture is also byte-identical to the previous
+binary. The final binary passes all six EM model/strand combinations and all
+24 existing STARsolo replay/representation comparisons.
+
+A separate full-brain GeneFull control forced support spilling with a zero-byte
+retained budget. All four scientific metric records and coverage counters match
+the original nine-mode baseline exactly; reported peak retained support capacity
+is zero. Its single observed run took 35.75 seconds and 2.789 GiB peak RSS. This
+is a storage-path correctness check and an illustrative memory/time tradeoff,
+not a repeated comparative benchmark.
+
+Commands, timing logs, source/binary and input identities, raw metrics, synthetic
+fixtures and MEX checksums are saved under the project run directory
+`runs/genefull-em-strands-opt-20260910`. The main benchmark has 24 successful
+complete-command runs. No biological ground-truth accuracy or changed nucleus
+calling is inferred from these performance experiments.

--- a/docs/genefull-em-validation.md
+++ b/docs/genefull-em-validation.md
@@ -1,0 +1,62 @@
+# GeneFull EM validation
+
+The recovery evaluator accepts `aie dev em --gene-full` for forward-strand
+libraries. It builds unique and multi-gene support using the GeneFull replay
+index, including ambiguity from overlapping spans at a single placement.
+Masking, ten EM iterations, and the emitted pooled layer retain their existing
+rules. The independent `--star` implementation remains Gene-only and conflicts
+with `--gene-full`.
+
+Tests cover intronic evidence, nested genes, mixed classes split across decoder
+batches, masking without unique-evidence leakage, missing-contig alternatives,
+conditional-score denominators, CLI model selection, packed/eager unmasked
+agreement, model metadata, and incompatible flags. The workspace suite passed
+457 tests with three pre-existing ignored tests; the updated CLI fixture also
+passed separately. Clippy with warnings denied passed.
+
+## Matched brain-nucleus experiment
+
+The same 6,460 original called nuclei define the scored population. Both models
+use 20% deterministic masking, seed 7, blend alpha 20, and ten updates. Pooled
+priors use every archive barcode after masking, as in the original sample-wide
+experiment. A constant group map restricts scoring without changing the base
+uniform/cell/pooled/blend estimators. Every accuracy denominator is evaluable
+masked UMI classes before one-mismatch collapse.
+
+| Counting model | Masked classes | Evaluable classes | Uniform top-1 | Cell top-1 | Pooled top-1 | Blend top-1 |
+|---|---:|---:|---:|---:|---:|---:|
+| Gene | 72,671 | 70,278 | 50.25% | 72.66% | 88.53% | 88.10% |
+| GeneFull | 231,351 | 156,884 | 43.16% | 68.93% | 74.90% | 76.13% |
+
+GeneFull loses the unique-evidence label from the remaining candidates for
+74,467 masked classes (32.19%). Conditional pooled accuracy is 74.90%; counting
+these exclusions as failures gives 50.79% over all masked classes. Seeds 17
+and 29 give 74.52% and 74.66% conditional pooled accuracy. The eligible truth
+population changes between Gene and GeneFull, so these are not paired scores
+on an identical target list or independently established biological labels.
+
+Among GeneFull targets with maximum pooled responsibility at least 0.9,
+74,650/80,412 (92.83%) have the correct top-1 label. Those targets account for
+51.3% of evaluable classes. Calibration therefore depends on the population;
+responsibilities should not be presented as universally calibrated probabilities.
+
+Scoring all archive barcodes instead gives pooled accuracy 90.85% for Gene
+(100,186 evaluable classes) and 76.81% for GeneFull (193,141). The original eager
+Gene scores used a different masking draw and candidate tie order; its 59.4%
+cell / 90.9% pooled result is historical, not the matched control above.
+
+## Annotation and extension controls
+
+Fresh matched STARsolo v32/v49 GeneFull matrices on these nuclei contain
+68,671,764 / 70,815,492 collapsed UMIs and differ by 6,570,870 in L1 count mass.
+Half-L1 divided by the v49 total is 4.6394%, compared with v49 replay deviation
+0.7456%. The fresh v32 Gene result reproduces the historical fixed-nucleus
+matrix exactly. GeneFull replay deviation at v32 is 0.7334%.
+
+The saved blanket extension adds 125.86% Gene UMIs but changes GeneFull UMIs by
+−0.82% on fixed nuclei. All exon intervals were preserved or expanded; the
+count reduction results from assignment and UMI filtering, not span contraction.
+The saved evidence-guided extension adds 4,608,988 GeneFull collapsed UMIs
+(6.4772%), retaining 87.6% of its absolute Gene gain. Neither annotation was
+retuned. GeneFull and Gene references use the same genome, strand, barcode,
+and UMI policies within each matched comparison.

--- a/docs/genefull-em-validation.md
+++ b/docs/genefull-em-validation.md
@@ -1,11 +1,12 @@
 # GeneFull EM validation
 
-The recovery evaluator accepts `aie dev em --gene-full` for forward-strand
-libraries. It builds unique and multi-gene support using the GeneFull replay
+The recovery evaluator accepts `aie dev em --gene-full`. The original manuscript
+experiment below used forward-strand libraries. It builds unique and multi-gene support using the GeneFull replay
 index, including ambiguity from overlapping spans at a single placement.
 Masking, ten EM iterations, and the emitted pooled layer retain their existing
-rules. The independent `--star` implementation remains Gene-only and conflicts
-with `--gene-full`.
+rules. Subsequent implementation adds `--solo-strand` to recovery and STAR-style
+EM, and supports `--gene-full --star`; see `genefull-em-strands-optimization.md`
+for the additional correctness checks and optimization measurements.
 
 Tests cover intronic evidence, nested genes, mixed classes split across decoder
 batches, masking without unique-evidence leakage, missing-contig alternatives,

--- a/docs/genefull-validation.md
+++ b/docs/genefull-validation.md
@@ -1,0 +1,140 @@
+# GeneFull validation
+
+Validated 2026-09-10 with Rust 1.89.0 and STAR 2.7.11b
+(`b1edc1208d91a53bf40ebae8669f71d50b994851`).
+
+## Implementation and correctness
+
+GeneFull indexes exon-derived gene spans separately by chromosome and strand.
+A placement's candidate set is the union of spans overlapping its aligned
+blocks on the accepted strand. Skipped introns alone do not create overlaps;
+splice-junction concordance is not required. Existing unique-gene assignment,
+best-gene selection and global UMI-class collapse are retained. No archive or
+compiled-annotation format changes were made.
+
+The indexed implementation agreed with an independent exhaustive exon-bound
+and overlap calculation for 6,000 query/strand combinations. Explicit fixtures
+cover half-open boundaries, introns, nested genes, disjoint isoforms, skipped
+and novel introns, reused gene identifiers on distinct chromosomes/strands,
+alternative placements, absent contigs, repeated class records and 1-mismatch
+collapse across reducer batches.
+
+`scripts/validate-genefull.py` runs a reproducible synthetic STARsolo experiment.
+All 24 comparisons passed: Gene/GeneFull × three strand policies × streaming,
+eager, compiled-annotation and direct-BAM replay. The corresponding MEX files
+were byte-identical across equivalent representations, and report/MEX model
+identity and incompatible flags were checked. A separate Python-client smoke
+run produced a report and a readable MEX result.
+
+The full Rust suite passed 456 tests (3 pre-existing ignored tests); Python
+passed 92 tests; distribution tooling passed 43 tests. Clippy with warnings
+as errors and the documentation build passed. Repository-wide `cargo fmt
+--check` still flags pre-existing formatting outside the changed regions;
+the base source was checked separately. New algorithm regions were formatted,
+and `git diff --check` passed.
+
+## Brain nuclei: fixed barcode set
+
+The primary comparison uses the same 6,460 Gene-called nuclei from the
+Brain_3p dataset. Raw output matrices were generated with the complete barcode
+list and subsequently restricted to those nuclei. Alignments in the archive
+were generated without the target annotation; reference matrices were produced
+by matched annotation-aware STARsolo processing. These are end-to-end replay
+comparisons, not a claim that the two alignment procedures are identical.
+
+| Matrix | Collapsed UMIs in 6,460 nuclei | Median UMIs/nucleus | Median detected genes/nucleus |
+|---|---:|---:|---:|
+| STARsolo Gene | 24,280,804 | 2,900 | 1,838 |
+| Replay Gene | 24,153,768 | 2,882.5 | 1,833 |
+| STARsolo GeneFull | 70,815,492 | 8,353 | 3,513 |
+| Replay GeneFull | 71,156,828 | 8,390.5 | 3,532 |
+
+For Gene, the L1 difference is 220,486 UMI counts; half-L1 divided by the
+STARsolo Gene total is 0.4540%. For GeneFull, L1 is 1,055,992; half-L1 divided
+by the STARsolo GeneFull total is 0.7456%. Half-L1 is a matrix-distance
+normalization, not a count of tracked molecules that physically moved.
+
+Switching replay from Gene to GeneFull adds 48,631,181 counts and removes
+1,628,121 across gene-by-nucleus entries, for a net gain of 47,003,060 UMIs
+and a 2.94599-fold total. Nested/overlapping genes and UMI filtering mean that
+some individual gene counts decrease even though the total rises.
+
+Default Gene output matches the saved earlier matrix, features and barcodes
+byte-for-byte. GeneFull replay from the full ingest BAM matches streaming
+archive replay byte-for-byte for all three MEX components and all assignment
+statistics. This tests the shared representation; compression can still differ
+from per-read STAR geometry, and replay does not recompute genome alignments.
+
+## Nucleus calling and downstream sensitivity
+
+STAR 2.7.11b `soloCellFiltering` with default `EmptyDrops_CR` was applied to
+each replay raw matrix separately:
+
+| Matrix | Called nuclei | Collapsed UMIs within its own called set |
+|---|---:|---:|
+| STARsolo Gene | 6,460 | 24,280,804 |
+| Replay Gene | 6,458 | 24,152,117 |
+| STARsolo GeneFull | 6,564 | 70,923,992 |
+| Replay GeneFull | 6,565 | 71,266,591 |
+
+Replay Gene and GeneFull share 6,446 called barcodes: GeneFull adds 119 and
+excludes 12 relative to Gene. Gene replay differs from the matching STARsolo
+calling list by four omitted and two added barcodes. GeneFull retains all
+6,564 STARsolo GeneFull calls and adds one. These calling contrasts are
+separate from the fixed-nucleus comparison above.
+
+For the fixed nuclei, a shared sensitivity analysis used log1p counts after
+10,000-count library normalization, 2,000 genes ranked by pooled variance,
+gene z-scores, 30 joint principal components and pooled k-means with 15
+clusters (seed 2718). Adjusted Rand indices were 0.98561 for STARsolo/replay
+Gene, 0.98048 for STARsolo/replay GeneFull and 0.33320 for replay Gene/GeneFull.
+Thus the counting-model change affects clustering far more than replay does
+under a fixed analysis. Cluster marker contrasts and marker detection counts
+were saved with explicit nucleus denominators. This exploratory analysis is
+not a test of cell-type ground truth or biological superiority.
+
+## Annotation changes and the existing extension
+
+All comparisons below use replay on the same 6,460 nuclei. Ensembl accessions
+are matched after removing the version while preserving `_PAR_Y` suffixes.
+
+| Change | Model | Before UMIs | After UMIs | Net gain / before total |
+|---|---|---:|---:|---:|
+| v32 → v49 | Gene | 22,642,472 | 24,153,768 | 6.6746% |
+| v32 → v49 | GeneFull | 68,990,832 | 71,156,828 | 3.1395% |
+| v49 → existing extended annotation | Gene | 24,153,768 | 29,415,412 | 21.7839% |
+| v49 → existing extended annotation | GeneFull | 71,156,828 | 75,765,816 | 6.4772% |
+
+The extension was reused as saved, without retuning. Its relative gain is
+smaller under intron-inclusive counting. No matched v32 GeneFull STARsolo
+matrix was available; the annotation-change table is an archive replay
+sensitivity analysis, not an additional STARsolo fidelity claim.
+
+## Assignment units: whole archive
+
+| Quantity | Denominator | Gene numerator | GeneFull numerator |
+|---|---:|---:|---:|
+| Records with ≥1 uniquely assigned representative | 130,270,701 archive records | 30,672,329 | 81,557,405 |
+| Uniquely assigned representatives | 184,680,609 representative rows | 44,325,139 | 116,961,267 |
+| Classes with uniquely assigned evidence | 122,483,959 UMI classes | 29,149,820 | 78,953,348 |
+
+Full-input collapsed UMI totals are 28,630,629 for Gene and 77,643,934 for
+GeneFull. These include barcodes outside the called-nucleus set. The earlier
+34% ratio divided assigned representatives by archive records; it was not a
+fraction of distinct records. The corrected record fractions are 23.55% and
+62.61%, respectively. Archive records can share a UMI class and are not counts
+of independently identified physical molecules.
+
+## Reproduction
+
+Use the three scripts `validate-genefull.py`, `compare-genefull-brain.py` and
+`summarize-genefull-effects.py` in `scripts/`. They require new output
+directories and preserve prior results. The comparison scripts require NumPy
+and SciPy; the synthetic test requires STAR 2.7.11b and the candidate `aie`.
+Raw replay reports bind archive/BAM, annotation and barcode inputs to content
+identities. The local experiment record retains commands, checksums, raw
+outputs, per-nucleus counts, markers and calling lists.
+
+Reference assignment code:
+[STAR geneFullAlignOverlap](https://github.com/alexdobin/STAR/blob/b1edc1208d91a53bf40ebae8669f71d50b994851/source/Transcriptome_geneFullAlignOverlap.cpp)
+and [exon-derived gene spans](https://github.com/alexdobin/STAR/blob/b1edc1208d91a53bf40ebae8669f71d50b994851/source/Transcriptome.cpp).

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gravlax-docs",
-  "version": "0.3.0",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gravlax-docs",
-      "version": "0.3.0",
+      "version": "0.2.2",
       "dependencies": {
         "@astrojs/starlight": "0.41.11",
         "astro": "7.2.10",

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gravlax-docs",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gravlax-docs",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "dependencies": {
         "@astrojs/starlight": "0.41.11",
         "astro": "7.2.10",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gravlax-docs",
   "type": "module",
-  "version": "0.3.0",
+  "version": "0.2.2",
   "private": true,
   "scripts": {
     "dev": "astro dev",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gravlax-docs",
   "type": "module",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "private": true,
   "scripts": {
     "dev": "astro dev",

--- a/docs/src/content/docs/cli/em.md
+++ b/docs/src/content/docs/cli/em.md
@@ -33,6 +33,7 @@ aie dev em sample.aie --gtf gencode.v49.gtf \
 | Option | Default | Description |
 |---|---|---|
 | `--gtf <GTF>` | required | Annotation defining the gene candidates |
+| `--gene-full` | off | Use intron-inclusive GeneFull candidates for forward-strand libraries; incompatible with `--star` |
 | `--mask <FRAC>` | `0.2` | Fraction of mixed classes to mask for the labeled evaluation; `0` switches to emission |
 | `--seed <SEED>` | `7` | Masking RNG seed |
 | `--alpha <ALPHA>` | `20` | Blend-mode global-prior weight |
@@ -58,6 +59,17 @@ aie dev em sample.aie --gtf gencode.v49.gtf \
 | `--star` | off | Use the STARsolo-compatible `--soloMultiMappers EM` design (per-cell, intersection candidate sets, STAR's init/zeroing/convergence) and emit `UniqueAndMult-EM.mtx` into `--emit` |
 | `--eager` | off | Use the historical full-materialization implementation as a semantic/performance reference |
 | `--plot <SVG/PNG>` | — | With a masked run, write a per-mode reliability diagram |
+
+`--gene-full` applies the same exon-derived gene spans as GeneFull replay when
+constructing unique and ambiguous evidence. Masking and the EM update rules are
+unchanged. For GeneFull, alternatives on unannotated chromosomes contribute no
+candidates; the historical Gene experiment retains its whole-row exclusion.
+Metrics record the counting model and scoped masked, truth-lost, and evaluable
+class counts. Accuracy is per evaluable UMI class before one-mismatch collapse;
+it is conditional on the unique-evidence label surviving masking. `--groups`
+restricts scoring to its barcodes; the pooled prior still uses all archive
+barcodes after masking. Classes eligible for evaluation can change between
+Gene and GeneFull, so their accuracies describe different labeled populations.
 
 ## Sharing models
 
@@ -146,9 +158,9 @@ Temporary shards are removed on success or error.
 ## The emitted layer
 
 `em.mtx` is an **additive, opt-in layer** of real-valued recovered counts: the
-base replay matrices are never modified. Responsibilities are calibrated, so
-they can be consumed as probabilities; thresholding at responsibility > 0.8
-keeps the layer's high-confidence core. Use `--star` to request the
+base replay matrices are never modified. Responsibilities are model-derived probabilities; assess calibration on comparable
+evidence before applying confidence thresholds. Calibration differs between
+Gene and GeneFull and between datasets. Use `--star` to request the
 STARsolo-compatible update scheme; cross-tool byte identity has not yet been
 established.
 

--- a/docs/src/content/docs/cli/em.md
+++ b/docs/src/content/docs/cli/em.md
@@ -1,9 +1,10 @@
 ---
 title: aie dev em
-description: Cross-cell EM multimapper recovery from the stored paralog evidence.
+description: Gene and GeneFull EM recovery from archived ambiguous gene evidence.
 ---
 
-EM multimapper recovery over the archive's paralog-pattern evidence. Two modes
+EM recovery over archived ambiguous gene evidence, including multiple placements
+and overlapping gene spans at a single placement. Two modes
 share one command:
 
 - **Evaluation** (default): a masked-evidence protocol scores recovery
@@ -26,6 +27,18 @@ aie dev em sample.aie --gtf gencode.v49.gtf
 # emit the recovered-counts layer:
 aie dev em sample.aie --gtf gencode.v49.gtf \
   --mask 0 --emit em-layer/ --barcodes barcodes.tsv
+
+# score the same called nuclei with four base models, fitting priors on all barcodes:
+aie dev em sample.aie --gtf gencode.v49.gtf --gene-full \
+  --solo-strand forward --eval-barcodes called-nuclei.tsv --metrics-json metrics.json
+
+# run only pooled recovery, preserving that model's complete-evaluation result:
+aie dev em sample.aie --gtf gencode.v49.gtf --gene-full \
+  --eval-barcodes called-nuclei.tsv --modes pooled --metrics-json pooled.json
+
+# STAR-style unique-plus-EM matrix with reverse-strand GeneFull assignment:
+aie dev em sample.aie --gtf gencode.v49.gtf --gene-full --solo-strand reverse \
+  --star --emit star-em/ --barcodes barcodes.tsv
 ```
 
 ## Options
@@ -33,11 +46,15 @@ aie dev em sample.aie --gtf gencode.v49.gtf \
 | Option | Default | Description |
 |---|---|---|
 | `--gtf <GTF>` | required | Annotation defining the gene candidates |
-| `--gene-full` | off | Use intron-inclusive GeneFull candidates for forward-strand libraries; incompatible with `--star` |
+| `--gene-full` | off | Use intron-inclusive GeneFull candidates; supported by recovery, eager, and STAR-style EM |
+| `--solo-strand <STRAND>` | `forward` | cDNA-alignment/gene relationship: `forward` (same), `reverse` (opposite), or `unstranded` (either); applies to both unique counts and ambiguous candidates |
 | `--mask <FRAC>` | `0.2` | Fraction of mixed classes to mask for the labeled evaluation; `0` switches to emission |
 | `--seed <SEED>` | `7` | Masking RNG seed |
 | `--alpha <ALPHA>` | `20` | Blend-mode global-prior weight |
-| `--groups <TSV>` | — | Two-column barcode/group map; adds group and hierarchical evaluation modes and fixes the scored cell set |
+| `--groups <TSV>` | — | Two-column barcode/group map; adds group and hierarchical evaluation modes and fixes the scored cell set unless overridden by `--eval-barcodes` |
+| `--eval-barcodes <TSV>` | — | One barcode per line; sets the scored population independently of group assignments and prior fitting; overrides the scoring population from `--groups` |
+| `--modes <LIST>` | four base modes, or nine with groups | Comma-separated subset of `uniform,cell,pooled,blend,group,hierarchical,convex,dirichlet-proxy,depth-hybrid`; group-derived modes require `--groups` |
+| `--support-memory-mib <MiB>` | `512` | Budget for retained compact support arrays; actual candidate volume triggers spill; `0` forces disk. Decoder scratch, spill buffers and final EM arrays are additional memory |
 | `--group-alpha <ALPHA>` | `20` | Hierarchical group-prior pseudo-count mass |
 | `--global-alpha <ALPHA>` | `5` | Hierarchical whole-sample pseudo-count mass |
 | `--convex-cell-weight <W>` | `0.10` | Candidate-normalized convex weight on the target-cell distribution |
@@ -56,7 +73,7 @@ aie dev em sample.aie --gtf gencode.v49.gtf \
 | `--candidate-genes-only` | off | Stop after writing `--candidate-genes-out` |
 | `--emit <DIR>` | — | With `--mask 0`: write `em.mtx` (real-valued, additive) into this directory; requires `--barcodes` |
 | `--barcodes <BARCODES>` | — | Barcode list defining emitted column order |
-| `--star` | off | Use the STARsolo-compatible `--soloMultiMappers EM` design (per-cell, intersection candidate sets, STAR's init/zeroing/convergence) and emit `UniqueAndMult-EM.mtx` into `--emit` |
+| `--star` | off | Use the STARsolo `--soloMultiMappers EM` design (per-cell, intersection candidate sets, STAR's init/zeroing/convergence) with the selected Gene/GeneFull model and strand; emit `UniqueAndMult-EM.mtx` into `--emit` |
 | `--eager` | off | Use the historical full-materialization implementation as a semantic/performance reference |
 | `--plot <SVG/PNG>` | — | With a masked run, write a per-mode reliability diagram |
 
@@ -66,10 +83,21 @@ unchanged. For GeneFull, alternatives on unannotated chromosomes contribute no
 candidates; the historical Gene experiment retains its whole-row exclusion.
 Metrics record the counting model and scoped masked, truth-lost, and evaluable
 class counts. Accuracy is per evaluable UMI class before one-mismatch collapse;
-it is conditional on the unique-evidence label surviving masking. `--groups`
-restricts scoring to its barcodes; the pooled prior still uses all archive
-barcodes after masking. Classes eligible for evaluation can change between
+it is conditional on the unique-evidence label surviving masking. `--eval-barcodes`
+restricts scoring without adding group models. If it is absent, `--groups`
+restricts scoring to its barcodes. The pooled prior still uses all archive
+barcodes after masking, including barcodes outside the scored population.
+Classes eligible for evaluation can change between
 Gene and GeneFull, so their accuracies describe different labeled populations.
+
+`--modes` runs the selected models in their usual canonical order; it does not
+change their candidate sets, initialization, ten updates, or scoring rules.
+Paired comparisons are emitted only when both participating modes are selected.
+Emission requires `pooled` among the selected modes. The older `--convex-only`,
+`--dirichlet-only`, and `--hybrid-only` flags remain available but cannot be
+combined with `--modes`. Scoring selection, mode selection and support-memory
+controls apply to the packed recovery implementation and cannot be combined
+with `--eager` or `--star`.
 
 ## Sharing models
 
@@ -153,7 +181,13 @@ deterministic cell shards, and stores candidates as flat `u32` labels with
 temporary shard streams and finalize one shard at a time; small inputs retain
 the in-memory path. On an evaluated 10,000-cell dataset this reduced peak RSS from
 7,653,508 to 3,846,008 KiB at 35.86 s, with byte-identical metrics and stdout.
-Temporary shards are removed on success or error.
+Temporary shards are removed on success or error. The support budget now checks
+the actual compact candidate volume before growing retained arrays; it can
+switch to disk partway through an archive. A record with several GeneFull
+candidates contributes several support words. `support_storage` in metrics
+reports whether spilling occurred and the peak retained support capacity in
+bytes. This budget is not a limit on total process RSS. Set `TMPDIR` to choose
+the filesystem for temporary shards.
 
 ## The emitted layer
 
@@ -161,8 +195,15 @@ Temporary shards are removed on success or error.
 base replay matrices are never modified. Responsibilities are model-derived probabilities; assess calibration on comparable
 evidence before applying confidence thresholds. Calibration differs between
 Gene and GeneFull and between datasets. Use `--star` to request the
-STARsolo-compatible update scheme; cross-tool byte identity has not yet been
-established.
+STARsolo update scheme. Synthetic GeneFull matrices agree with STARsolo 2.7.11b
+within text-output rounding for all three strand policies, including nested,
+antisense, and multiple-placement evidence. General byte identity is not claimed:
+the archive retains representative geometry, and unique-count replay has its
+own UMI filtering and tie rules. In particular, a Gene fixture with tied unique
+support retains the lowest gene id in replay while STARsolo removes that UMI;
+the EM increment agrees separately. The STAR-style matrix combines unique
+replay UMIs after one-mismatch collapse with fractional counts for multi-only
+raw UMI classes. Its metadata records this counting unit, model and strand.
 
 The built-in masked analysis is useful but does not prove that pooled or
 group-aware sharing is unbiased: it defines truth using mixed classes whose

--- a/docs/src/content/docs/cli/replay-rows.md
+++ b/docs/src/content/docs/cli/replay-rows.md
@@ -1,6 +1,6 @@
 ---
 title: aie replay-rows
-description: Quantify a compatible GTF from an .aie index using Gene or Velocyto semantics.
+description: Quantify a compatible GTF from an .aie index using Gene, GeneFull, or Velocyto semantics.
 ---
 
 Quantify a compatible GTF from an `.aie` archive. Replay uses the fixed genome
@@ -33,6 +33,7 @@ aie replay-rows sample.aie \
 | `--gtf <GTF/AIC>` | required | The GTF or compiled `.aic` annotation to replay; coordinates and contig names must match the archive's reference genome |
 | `--barcodes <BARCODES>` | required | Barcode list defining output column order (e.g. a raw `barcodes.tsv`) |
 | `--out-dir <OUT_DIR>` | required | Receives `matrix.mtx`, `features.tsv`, `barcodes.tsv` |
+| `--gene-full` | off | Count aligned-block overlaps with full gene spans, including introns; incompatible with `--velocity` and `--audit-multigene` |
 | `--velocity` | off | Emit STARsolo Velocyto semantics (spliced/unspliced/ambiguous matrices) instead of Gene |
 | `--audit-multigene` | off | Print the multi-gene ambiguity audit (the EM upside bound) instead of emitting a matrix |
 | `--solo-strand <STRAND>` | `forward` | STARsolo-compatible assignment strand: `forward`, `reverse`, or `unstranded`; 10x 5′ Gene expression uses `reverse` |
@@ -53,6 +54,36 @@ filtering, and greedy 1-mismatch tie-merging over the stored UMI adjacency
 graph. `--velocity` additionally ports the Velocyto transcript-set
 intersection with its flank-tolerance classifier, applying the same UMI
 correction map the Gene collapse produces.
+
+### Intron-inclusive GeneFull
+
+`--gene-full` uses the span from the first to the last annotated exon of each
+gene, including gaps between disjoint isoforms. It unions genes overlapping
+any aligned block on the selected strand. Junction concordance is not
+required, and a gene inside a skipped alignment intron is not hit solely
+because it lies within the outer alignment span. Gene spans are kept separate
+by chromosome and strand when a gene identifier occurs in multiple contexts;
+they are never extended across chromosomes or opposing strands.
+
+This is STARsolo `GeneFull`, not `GeneFull_ExonOverIntron` or
+`GeneFull_Ex50pAS`. The existing best-gene filtering and global UMI-collapse
+policy apply after assignment. Overlapping/nested genes can make evidence
+ambiguous, so GeneFull need not increase every individual gene count.
+
+```sh
+aie replay-rows nuclei.aie --gene-full --gtf annotation.aic \
+  --barcodes raw-barcodes.tsv --out-dir genefull/ --report-format json
+```
+
+The barcode file orders columns and must include all counted barcodes. Replay
+does not call nuclei. Emit both models with the same raw barcode list, then
+subset both matrices to the same called nuclei to isolate counting-model
+effects. Evaluate changes in nucleus calling separately. Historical
+span-extreme archives retain representative geometry, not every read; use
+`--geometry-fidelity` at ingest when exact unique-read geometry is required.
+Deletion-spanning blocks and representative reduction can differ from STAR's
+per-read geometry. Neither counting model restores discarded sequence or
+recomputes genome alignments.
 
 For repeated replay, compile the GTF once with
 [`aie compile-annotation`](/gravlax/cli/compile-annotation/) and pass the
@@ -107,3 +138,37 @@ transaction for the whole directory. Report and metadata destinations are
 preflighted before replay; each metadata/report file is itself atomically
 installed without replacement. For a fresh, unambiguous result, use a new
 output directory.
+
+## Counting units
+
+Reports identify `counting_model` as `Gene`, `GeneFull`, or `Velocyto` in
+`provenance.parameters`. Gene and GeneFull additionally report
+`assignment_statistics`, covering **all consumed input, without restriction to called nuclei**:
+
+| Field | Counting unit and denominator |
+|---|---|
+| `molecule_records` | Archived locus records; the same cell/UMI class may occur in several records |
+| `assigned_molecule_records` | Records with at least one uniquely assigned representative; denominator `molecule_records` |
+| `representative_rows` | Unique-chain representatives plus aggregated alternative-placement signatures |
+| `assigned_representative_rows` | Rows with exactly one candidate gene; denominator `representative_rows` |
+| `umi_classes` | Ingest UMI classes across all input cells |
+| `assigned_umi_classes` | Classes with uniquely assigned evidence before 1-mismatch collapse; denominator `umi_classes` |
+
+`assigned_molecules` now aliases `assigned_molecule_records`. Earlier reports
+incorrectly populated it with a representative-row count. `counted_umis` and
+`matrix_entries` describe the full input count map. Subset the emitted matrix and sum it to
+obtain UMIs in a called-nucleus set.
+Archive records, representative rows, UMI classes, and final collapsed UMIs
+are distinct units and cannot be substituted into one another's fractions.
+
+## Python
+
+```python
+from gravlax import Client, read_mex
+
+report = Client().replay(
+    "nuclei.aie", "annotation.aic", "raw-barcodes.tsv", "genefull",
+    gene_full=True,
+)
+counts = read_mex("genefull")
+```

--- a/packaging/conda/local/meta.yaml
+++ b/packaging/conda/local/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = environ.get("GRAVLAX_VERSION", "0.2.1") %}
+{% set version = environ.get("GRAVLAX_VERSION", "0.3.0") %}
 
 package:
   name: gravlax

--- a/packaging/conda/local/meta.yaml
+++ b/packaging/conda/local/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = environ.get("GRAVLAX_VERSION", "0.3.0") %}
+{% set version = environ.get("GRAVLAX_VERSION", "0.2.2") %}
 
 package:
   name: gravlax

--- a/python/README.md
+++ b/python/README.md
@@ -263,3 +263,18 @@ The core test suite needs no optional scientific Python packages:
 cd python
 PYTHONPATH=src python -m unittest discover -s tests -v
 ```
+
+### GeneFull replay
+
+```python
+report = client.replay(
+    "nuclei.aie", "annotation.aic", "called-nuclei.tsv", "genefull",
+    gene_full=True,
+)
+```
+
+The barcode list orders columns and must cover all counted barcodes; it does
+not call nuclei. Gene is the
+default model. `gene_full=True` includes intronic gene-span overlaps and
+conflicts with `velocity=True`. Assignment statistics cover all input and distinguish records, representatives, and UMI
+classes from collapsed UMI counts.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gravlax-client"
-version = "0.3.0"
+version = "0.2.2"
 description = "Dependency-light Python client for the Gravlax aie command-line interface"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gravlax-client"
-version = "0.2.1"
+version = "0.3.0"
 description = "Dependency-light Python client for the Gravlax aie command-line interface"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/python/src/gravlax/__init__.py
+++ b/python/src/gravlax/__init__.py
@@ -158,4 +158,4 @@ __all__ = [
     "read_mex",
 ]
 
-__version__ = "0.3.0"
+__version__ = "0.2.2"

--- a/python/src/gravlax/__init__.py
+++ b/python/src/gravlax/__init__.py
@@ -158,4 +158,4 @@ __all__ = [
     "read_mex",
 ]
 
-__version__ = "0.2.1"
+__version__ = "0.3.0"

--- a/python/src/gravlax/client.py
+++ b/python/src/gravlax/client.py
@@ -1281,6 +1281,45 @@ class Client:
         result = self.run(args)
         return AnnotationComparisonResult.from_json(result.stdout)
 
+    def replay(
+        self,
+        archive: PathToken,
+        annotation_file: PathToken,
+        barcodes: PathToken,
+        out_dir: PathToken,
+        *,
+        gene_full: bool = False,
+        velocity: bool = False,
+        solo_strand: str = "forward",
+        eager: bool = False,
+    ) -> UniformResultBundle:
+        """Write a MEX matrix and return its operation report.
+
+        GeneFull counts overlaps with exon-derived gene spans, including introns.
+        The barcode file orders output columns and must cover all counted barcodes.
+        This does not call nuclei. Assignment statistics cover all input.
+        """
+
+        for name, value in (("gene_full", gene_full), ("velocity", velocity), ("eager", eager)):
+            if not isinstance(value, bool):
+                raise TypeError(f"{name} must be bool")
+        if gene_full and velocity:
+            raise ValueError("gene_full and velocity are mutually exclusive")
+        solo_strand = _choice(solo_strand, {"forward", "reverse", "unstranded"}, "solo_strand")
+        args: list[PathToken] = [
+            "replay-rows", _option("gtf", annotation_file),
+            _option("barcodes", barcodes), _option("out-dir", out_dir),
+            _option("solo-strand", solo_strand), "--report-format=json",
+        ]
+        if gene_full:
+            args.append("--gene-full")
+        if velocity:
+            args.append("--velocity")
+        if eager:
+            args.append("--eager")
+        args.extend(["--", _token(archive, "archive")])
+        return self.result_bundle(args)
+
     def transcript_ecs(
         self,
         archive: PathToken,

--- a/python/tests/test_uniform_client.py
+++ b/python/tests/test_uniform_client.py
@@ -17,6 +17,25 @@ def completed(argv, stdout: str, *, returncode: int = 0, stderr: str = ""):
 
 
 class UniformClientTests(unittest.TestCase):
+    def test_replay_model_validation_and_safe_path_tokens(self):
+        client = Client(binary="definitely-not-run")
+        with self.assertRaisesRegex(ValueError, "mutually exclusive"):
+            client.replay("a", "b", "c", "d", gene_full=True, velocity=True)
+        with self.assertRaisesRegex(TypeError, "bool"):
+            client.replay("a", "b", "c", "d", gene_full="yes")
+        with self.assertRaisesRegex(ValueError, "solo_strand"):
+            client.replay("a", "b", "c", "d", solo_strand="invalid")
+        with patch.object(client, "result_bundle", return_value="report") as run:
+            result = client.replay("-sample.aie", "annotation file.gtf", "bc.tsv", "out dir", gene_full=True)
+            self.assertEqual(result, "report")
+            argv = run.call_args.args[0]
+            self.assertEqual(argv[-2:], ["--", "-sample.aie"])
+            self.assertIn("--gene-full", argv)
+            self.assertIn("--gtf=annotation file.gtf", argv)
+            self.assertIn("--report-format=json", argv)
+            client.replay("a", "b", "c", "d")
+            self.assertNotIn("--gene-full", run.call_args.args[0])
+
     @patch("gravlax.client.subprocess.run")
     def test_region_wrapper_requests_the_uniform_json_contract(self, run):
         run.return_value = completed([], json.dumps(region_bundle()))

--- a/scripts/benchmark-genefull-em.py
+++ b/scripts/benchmark-genefull-em.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Interleaved complete-command GeneFull benchmarks with result equality gates.
+
+--binaries contains aie-baseline, aie-features, aie-memory and aie-index.
+These isolate mode selection, actual-support spilling, and the block/strand index.
+Input project files are read only; --out must be new. Python standard library only.
+"""
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import statistics
+import subprocess
+import time
+
+
+def digest(path):
+    with path.open('rb') as f:
+        return hashlib.file_digest(f, 'sha256').hexdigest()
+
+
+def scientific(data):
+    return {m['name']: m for m in data['modes']}, data['evaluation_counts']
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--project', type=Path, required=True)
+    parser.add_argument('--binaries', type=Path, required=True)
+    parser.add_argument('--out', type=Path, required=True)
+    parser.add_argument('--repetitions', type=int, default=3)
+    args = parser.parse_args()
+    root, binaries, out = args.project.resolve(), args.binaries.resolve(), args.out.resolve()
+    if args.repetitions < 1:
+        parser.error('repetitions must be positive')
+    out.mkdir(parents=True, exist_ok=False)
+    (out / 'tmp').mkdir()
+    archive = root / 'runs/archive/d2p.aie'
+    annotation = root / 'runs/genefull-20260910/gencode-v49.aic'
+    called = root / 'runs/oracle/d2p/v49/Solo.out/Gene/filtered/barcodes.tsv'
+    barcodes = root / 'runs/oracle/d2p/v49/Solo.out/Gene/raw/barcodes.tsv'
+    groups = root / 'runs/genefull-paper-20260910/fixed-nuclei-groups.tsv'
+    env = dict(os.environ, RAYON_NUM_THREADS='16', TMPDIR=str(out / 'tmp'))
+    cases = [('nine-baseline', 'baseline', 'nine'), ('nine-index', 'index', 'nine'),
+             ('four-features', 'features', 'four'), ('four-memory', 'memory', 'four'),
+             ('four-index', 'index', 'four'), ('pooled-index', 'index', 'pooled'),
+             ('replay-baseline', 'baseline', 'replay'), ('replay-index', 'index', 'replay')]
+    manifest = {'threads': 16, 'hostname': os.uname().nodename, 'archive': str(archive),
+                'annotation': str(annotation), 'called_nuclei': len(called.read_text().splitlines()),
+                'binary_sha256': {v: digest(binaries / f'aie-{v}') for v in ['baseline', 'features', 'memory', 'index']},
+                'scope': 'EM scores fixed 6460 nuclei; priors use all archive barcodes. Replay emits all raw barcodes.',
+                'case_order': cases, 'repetitions': args.repetitions, 'runs': []}
+    # Read-through warmup; no root cache eviction and no changes to archive data.
+    manifest['archive_sha256'] = digest(archive)
+    reference = None
+    replay_reference = None
+    for rep in range(args.repetitions):
+        order = cases[rep:] + cases[:rep]
+        for name, version, mode in order:
+            label = f'{rep+1}-{name}'
+            metrics = out / f'{label}.json'
+            binary = binaries / f'aie-{version}'
+            if mode == 'replay':
+                argv = [binary, 'replay-rows', archive, '--gtf', annotation, '--gene-full',
+                        '--barcodes', barcodes, '--out-dir', out / label]
+            else:
+                argv = [binary, 'dev', 'em', archive, '--gtf', annotation, '--gene-full',
+                        '--mask', '0.2', '--seed', '7', '--alpha', '20', '--metrics-json', metrics]
+                argv += ['--groups', groups] if mode == 'nine' else ['--eval-barcodes', called]
+                if mode == 'pooled':
+                    argv += ['--modes', 'pooled']
+            argv = list(map(str, argv))
+            (out / f'{label}-command.json').write_text(json.dumps(argv, indent=2) + '\n')
+            timing = out / f'{label}.time'
+            started = time.time()
+            with (out / f'{label}.log').open('w') as stream:
+                subprocess.run(['/usr/bin/time', '-f', '%e\t%M\t%U\t%S', '-o', str(timing), *argv],
+                               stdout=stream, stderr=subprocess.STDOUT, env=env, check=True)
+            elapsed, rss, user, system = map(float, timing.read_text().split())
+            result = {'case': name, 'rep': rep + 1, 'started_unix': started,
+                      'elapsed_seconds': elapsed, 'peak_rss_kib': int(rss), 'user_seconds': user,
+                      'system_seconds': system, 'command_file': f'{label}-command.json'}
+            if mode == 'replay':
+                observed = {f: digest(out / label / f) for f in ['matrix.mtx', 'features.tsv', 'barcodes.tsv']}
+                if replay_reference is None:
+                    replay_reference = observed
+                assert observed == replay_reference, (label, observed, replay_reference)
+                result['matrix_sha256'] = observed
+            else:
+                data = json.loads(metrics.read_text())
+                observed, coverage = scientific(data)
+                if reference is None:
+                    assert mode == 'nine'
+                    reference = (observed, coverage)
+                assert coverage == reference[1], (label, coverage, reference[1])
+                assert observed == {name: reference[0][name] for name in observed}, label
+                expected = 9 if mode == 'nine' else 4 if mode == 'four' else 1
+                assert len(observed) == expected, label
+                result['modes_verified'] = list(observed)
+                result['support_storage'] = data.get('support_storage')
+            manifest['runs'].append(result)
+            (out / 'results.json').write_text(json.dumps(manifest, indent=2) + '\n')
+            print(label, f'{elapsed:.2f}s', f'{rss / 1024**2:.3f} GiB', 'equality passed', flush=True)
+    manifest['summary'] = {name: {
+        'median_seconds': statistics.median(r['elapsed_seconds'] for r in manifest['runs'] if r['case'] == name),
+        'median_peak_rss_kib': statistics.median(r['peak_rss_kib'] for r in manifest['runs'] if r['case'] == name),
+    } for name, _, _ in cases}
+    manifest['passed'] = True
+    (out / 'results.json').write_text(json.dumps(manifest, indent=2) + '\n')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/compare-genefull-brain.py
+++ b/scripts/compare-genefull-brain.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Matched Gene/GeneFull comparisons with explicit units and nucleus-set contrasts.
+
+Inputs are preserved. Outputs include integer mass differences (no assumption
+that half the L1 distance counts physically relocated molecules), matched
+per-nucleus summaries, and a deterministic shared PCA/k-means sensitivity analysis.
+"""
+import argparse
+import json
+from pathlib import Path
+import numpy as np
+from scipy import io, sparse
+from scipy.sparse.linalg import svds
+from scipy.cluster.vq import kmeans2
+
+
+def load_selected(path, selected):
+    genes=[line.split('\t')[0] for line in (path/'features.tsv').read_text().splitlines()]
+    names=[line.split('\t')[1] for line in (path/'features.tsv').read_text().splitlines()]
+    assert len(set(genes))==len(genes)
+    ids={b:i for i,b in enumerate(selected)}
+    columns=np.fromiter((ids.get(line.strip(),-1) for line in (path/'barcodes.tsv').open()),dtype=np.int32)
+    assert sum(columns>=0)==len(selected),'missing or repeated selected barcodes'
+    m=io.mmread(path/'matrix.mtx').tocoo()
+    assert m.shape==(len(genes),len(columns))
+    assert np.all(m.data>=0) and np.all(m.data==np.floor(m.data))
+    raw_total=int(m.data.sum()); raw_nnz=int(np.count_nonzero(m.data))
+    cols=columns[m.col];keep=cols>=0
+    result=sparse.coo_matrix((m.data[keep].astype(np.int64),(m.row[keep],cols[keep])),shape=(len(genes),len(selected))).tocsr()
+    result.sum_duplicates();result.eliminate_zeros()
+    return result,genes,names,{'raw_collapsed_umis':raw_total,'raw_matrix_nonzero_entries':raw_nnz,'raw_barcode_columns':len(columns)}
+
+
+def distribution(values):
+    return {'min':float(np.min(values)),'median':float(np.median(values)),
+            'p10':float(np.quantile(values,.1)),'p90':float(np.quantile(values,.9)),
+            'max':float(np.max(values)),'mean':float(np.mean(values))}
+
+
+def compare(a,b):
+    d=(b-a).tocoo();gain=int(d.data[d.data>0].sum());loss=int(-d.data[d.data<0].sum())
+    total_a=int(a.sum());total_b=int(b.sum())
+    ac=np.asarray(a.sum(axis=0)).ravel();bc=np.asarray(b.sum(axis=0)).ravel()
+    l1=np.asarray(abs(b-a).sum(axis=0)).ravel()
+    return {'nuclei':a.shape[1],'gene_rows':a.shape[0],
+            'a_collapsed_umis':total_a,'b_collapsed_umis':total_b,
+            'positive_count_difference_umis':gain,'negative_count_difference_umis':loss,
+            'net_count_difference_umis':total_b-total_a,'l1_count_difference_umis':gain+loss,
+            'l1_over_a_umis':(gain+loss)/max(1,total_a),
+            'half_l1_over_a_umis':(gain+loss)/(2*max(1,total_a)),
+            'changed_gene_by_nucleus_entries':int(np.count_nonzero(d.data)),
+            'possible_gene_by_nucleus_entries':int(a.shape[0]*a.shape[1]),
+            'changed_nuclei':int(np.count_nonzero(l1)),
+            'a_umis_per_nucleus':distribution(ac),'b_umis_per_nucleus':distribution(bc),
+            'a_genes_per_nucleus':distribution(np.asarray((a>0).sum(axis=0)).ravel()),
+            'b_genes_per_nucleus':distribution(np.asarray((b>0).sum(axis=0)).ravel()),
+            'paired_umi_ratio_b_over_a':distribution(bc/np.maximum(ac,1))}
+
+
+def ari(a,b):
+    _,aa=np.unique(a,return_inverse=True);_,bb=np.unique(b,return_inverse=True)
+    c=np.zeros((aa.max()+1,bb.max()+1),dtype=np.int64);np.add.at(c,(aa,bb),1)
+    choose=lambda x:np.sum(x*(x-1)/2)
+    n=choose(c);sa=choose(c.sum(axis=1));sb=choose(c.sum(axis=0));pairs=len(a)*(len(a)-1)/2
+    expected=sa*sb/pairs;denom=(sa+sb)/2-expected
+    return float((n-expected)/denom) if denom else 1.
+
+
+def downstream(matrices,genes,names,barcodes,out):
+    labels=list(matrices)
+    lengths=[m.shape[1] for m in matrices.values()]
+    normalized=[]
+    for m in matrices.values():
+        x=m.T.astype(np.float64).tocsr();tot=np.asarray(x.sum(axis=1)).ravel()
+        x=sparse.diags(1e4/np.maximum(tot,1))@x;x.data=np.log1p(x.data)
+        normalized.append(x)
+    pooled=sparse.vstack(normalized).tocsr()
+    mean=np.asarray(pooled.mean(axis=0)).ravel()
+    var=np.asarray(pooled.power(2).mean(axis=0)).ravel()-mean**2
+    selected=np.argsort(var,kind='stable')[-2000:]
+    x=pooled[:,selected].toarray();x-=x.mean(axis=0);x/=np.maximum(x.std(axis=0),1e-8)
+    u,s,_=svds(x,k=30,random_state=314159)
+    scores=u[:,::-1]*s[::-1]
+    _,pooled_cluster=kmeans2(scores,15,iter=100,minit='++',seed=2718)
+    assignments={};start=0
+    for label,n in zip(labels,lengths):
+        assignments[label]=pooled_cluster[start:start+n]
+        start+=n
+    result={'method':'joint log1p(10000 library-normalized counts), pooled 2000 highest-variance genes, gene z-scores, 30 joint PCs, shared pooled k-means k=15, seed 2718',
+            'scope':'fixed Gene-called nuclei; exploratory sensitivity, not cell-type accuracy',
+            'pairwise_adjusted_rand_index':{a+' vs '+b:ari(assignments[a],assignments[b]) for i,a in enumerate(labels) for b in labels[i+1:]}}
+    (out/'downstream.json').write_text(json.dumps(result,indent=2)+'\n')
+    with (out/'cluster-assignments.tsv').open('w') as f:
+        f.write('barcode\t'+'\t'.join(labels)+'\n')
+        for i,bc in enumerate(barcodes):f.write(bc+'\t'+'\t'.join(str(assignments[l][i]) for l in labels)+'\n')
+    with (out/'cluster-markers.tsv').open('w') as f:
+        f.write('matrix\tcluster\tnuclei\tgene_id\tgene_name\tmean_log1p_in\tmean_log1p_out\tdifference\n')
+        for label,norm in zip(labels,normalized):
+            cluster=assignments[label]
+            for k in range(15):
+                mask=cluster==k
+                if not mask.any() or mask.all():continue
+                inside=np.asarray(norm[mask].mean(axis=0)).ravel();outside=np.asarray(norm[~mask].mean(axis=0)).ravel()
+                difference=inside-outside
+                for g in np.argsort(difference)[-10:][::-1]:
+                    f.write(f'{label}\t{k}\t{mask.sum()}\t{genes[g]}\t{names[g]}\t{inside[g]}\t{outside[g]}\t{difference[g]}\n')
+    panel=['SLC17A7','GAD1','GAD2','AQP4','GFAP','MBP','PLP1','PDGFRA','CSF1R','PTPRC','CLDN5','FLT1']
+    with (out/'marker-detection.tsv').open('w') as f:
+        f.write('matrix\tgene_id\tgene_name\tdetected_nuclei\tdenominator_nuclei\ttotal_umis\n')
+        for label,m in matrices.items():
+            for name in panel:
+                for g in [i for i,n in enumerate(names) if n==name]:
+                    f.write(f'{label}\t{genes[g]}\t{name}\t{m[g].count_nonzero()}\t{m.shape[1]}\t{int(m[g].sum())}\n')
+    return result
+
+
+def main():
+    ap=argparse.ArgumentParser()
+    ap.add_argument('--reference',type=Path,required=True,help='STAR Solo.out directory')
+    ap.add_argument('--gene',type=Path,required=True)
+    ap.add_argument('--gene-full',type=Path,required=True)
+    ap.add_argument('--out',type=Path,required=True)
+    ap.add_argument('--skip-downstream',action='store_true')
+    args=ap.parse_args();out=args.out;out.mkdir(parents=True,exist_ok=False)
+    called={m:set((args.reference/m/'filtered/barcodes.tsv').read_text().splitlines()) for m in ['Gene','GeneFull']}
+    union=sorted(called['Gene']|called['GeneFull']);idx={b:i for i,b in enumerate(union)}
+    sets={'fixed_Gene_called':sorted(called['Gene']),'intersection_called':sorted(called['Gene']&called['GeneFull']),
+          'GeneFull_called':sorted(called['GeneFull']),'Gene_only_called':sorted(called['Gene']-called['GeneFull']),
+          'GeneFull_only_called':sorted(called['GeneFull']-called['Gene'])}
+    for name,bc in sets.items():(out/(name+'.barcodes.tsv')).write_text(''.join(b+'\n' for b in bc))
+    paths={'STAR_Gene':args.reference/'Gene/raw','STAR_GeneFull':args.reference/'GeneFull/raw',
+           'replay_Gene':args.gene,'replay_GeneFull':args.gene_full}
+    matrices={};raw={};gene_order=None;gene_names=None
+    for label,path in paths.items():
+        m,genes,names,stats=load_selected(path,union)
+        if gene_order is None:gene_order=genes;gene_names=names
+        elif genes!=gene_order:
+            assert set(genes)==set(gene_order)
+            positions={g:i for i,g in enumerate(genes)};m=m[[positions[g] for g in gene_order]]
+        matrices[label]=m;raw[label]=stats;sparse.save_npz(out/(label+'.npz'),m)
+    (out/'genes.tsv').write_text(''.join(g+'\t'+n+'\n' for g,n in zip(gene_order,gene_names)))
+    (out/'union.barcodes.tsv').write_text(''.join(b+'\n' for b in union))
+    results={'counting_units':{'matrix':'collapsed gene-specific UMI counts','nucleus':'distinct called barcode','mass_difference':'differences between integer matrix entries; not tracked molecular identities'},
+             'calling':{'Gene_called':len(called['Gene']),'GeneFull_called':len(called['GeneFull']),
+                        'intersection':len(sets['intersection_called']),'union':len(union),
+                        'Gene_only':len(sets['Gene_only_called']),'GeneFull_only':len(sets['GeneFull_only_called']),
+                        'jaccard_intersection_over_union':len(sets['intersection_called'])/len(union)},'raw':raw,'comparisons':{}}
+    for scope,bc in sets.items():
+        if not bc:continue
+        cols=[idx[b] for b in bc]
+        selected={label:m[:,cols] for label,m in matrices.items()}
+        for a,b in [('STAR_Gene','replay_Gene'),('STAR_GeneFull','replay_GeneFull'),('replay_Gene','replay_GeneFull'),('STAR_Gene','STAR_GeneFull')]:
+            results['comparisons'][scope+'/'+a+'_to_'+b]=compare(selected[a],selected[b])
+        if scope=='fixed_Gene_called':
+            if not args.skip_downstream:results['downstream']=downstream(selected,gene_order,gene_names,bc,out)
+            with (out/'per-nucleus.tsv').open('w') as f:
+                f.write('barcode\t'+'\t'.join(label+'_umis\t'+label+'_genes' for label in selected)+'\n')
+                arrays=[(np.asarray(m.sum(axis=0)).ravel(),np.asarray((m>0).sum(axis=0)).ravel()) for m in selected.values()]
+                for i,barcode in enumerate(bc):f.write(barcode+'\t'+'\t'.join(str(int(x[i])) for pair in arrays for x in pair)+'\n')
+    (out/'summary.json').write_text(json.dumps(results,indent=2)+'\n')
+    print(json.dumps({'calling':results['calling'],'fixed_nucleus_comparisons':{k:v for k,v in results['comparisons'].items() if k.startswith('fixed')}},indent=2))
+
+if __name__=='__main__':main()

--- a/scripts/plot-genefull-validation.py
+++ b/scripts/plot-genefull-validation.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Render a standalone scientific summary from completed comparison artifacts."""
+import argparse
+import json
+from pathlib import Path
+import numpy as np
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+
+ap=argparse.ArgumentParser();ap.add_argument('--comparison',type=Path,required=True);ap.add_argument('--calling',type=Path,required=True);ap.add_argument('--out',type=Path,required=True)
+a=ap.parse_args();a.out.mkdir(parents=True,exist_ok=False)
+s=json.loads((a.comparison/'summary.json').read_text());c=json.loads(a.calling.read_text())
+p=np.genfromtxt(a.comparison/'per-nucleus.tsv',names=True,delimiter='\t',dtype=None,encoding='utf-8')
+plt.rcParams.update({'font.size':10,'axes.spines.top':False,'axes.spines.right':False,'pdf.fonttype':42})
+fig,axs=plt.subplots(2,2,figsize=(10,8),layout='constrained')
+for ax,unit,title in [(axs[0,0],'umis','A  Collapsed UMIs per fixed nucleus'),(axs[0,1],'genes','B  Detected genes per fixed nucleus')]:
+ x=p['replay_Gene_'+unit];y=p['replay_GeneFull_'+unit]
+ ax.hexbin(x,y,gridsize=45,mincnt=1,xscale='log',yscale='log',cmap='Blues')
+ lo=min(x.min(),y.min());hi=max(x.max(),y.max());ax.plot([lo,hi],[lo,hi],color='0.4',ls='--',lw=1)
+ ax.set(xlabel='Gene',ylabel='GeneFull',title=title)
+ ax.text(.04,.95,'Same 6,460 nuclei',transform=ax.transAxes,va='top')
+ax=axs[1,0]
+values=[100*s['comparisons']['fixed_Gene_called/STAR_'+m+'_to_replay_'+m]['half_l1_over_a_umis'] for m in ['Gene','GeneFull']]
+ax.bar(['Gene','GeneFull'],values,color=['#b7683a','#326b92'],width=.55)
+for i,v in enumerate(values):ax.text(i,v+.015,f'{v:.3f}%',ha='center')
+ax.set(ylabel='100 × half-L1 / matched STARsolo UMI total',ylim=(0,1),title='C  End-to-end matrix difference')
+ax=axs[1,1];v=c['comparisons']['replay_Gene to replay_GeneFull']
+ax.barh(['Gene only','Shared','GeneFull only'],[v['a_only'],v['intersection'],v['b_only']],color=['#b7683a','#71816d','#326b92'])
+ax.set(xscale='log',xlabel='Number of called barcodes (log scale)',title='D  Nucleus calling on each replay matrix')
+for i,n in enumerate([v['a_only'],v['intersection'],v['b_only']]):ax.text(n*1.08,i,f'{n:,}',va='center')
+ax.set_xlim(1,15000)
+fig.suptitle('GeneFull replay in brain nuclei',fontsize=16)
+for ext in ['png','pdf']:fig.savefig(a.out/f'genefull-summary.{ext}',dpi=180)

--- a/scripts/summarize-genefull-effects.py
+++ b/scripts/summarize-genefull-effects.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Summarize saved nucleus calling and annotation perturbations without overwrites."""
+import argparse
+import importlib.util
+import json
+from pathlib import Path
+import re
+import numpy as np
+from scipy import io,sparse
+
+spec=importlib.util.spec_from_file_location('comparison',Path(__file__).with_name('compare-genefull-brain.py'))
+comparison=importlib.util.module_from_spec(spec);spec.loader.exec_module(comparison)
+
+
+def stable_id(gene):
+    return re.sub(r'^(ENSG\d+)\.\d+(_PAR_Y)?$',lambda m:m[1]+(m[2] or ''),gene)
+
+
+def align(matrix,genes,union):
+    assert len(set(genes))==len(genes),'duplicate normalized gene identifiers'
+    mapping={g:i for i,g in enumerate(union)};coo=matrix.tocoo()
+    row=np.array([mapping[g] for g in genes],dtype=np.int32)[coo.row]
+    return sparse.coo_matrix((coo.data,(row,coo.col)),shape=(len(union),matrix.shape[1])).tocsr()
+
+
+def main():
+    ap=argparse.ArgumentParser();ap.add_argument('--run',type=Path,required=True)
+    ap.add_argument('--reference',type=Path,required=True);ap.add_argument('--out',type=Path,required=True)
+    args=ap.parse_args();out=args.out;out.mkdir(parents=True,exist_ok=False);run=args.run
+    fixed=(args.reference/'Gene/filtered/barcodes.tsv').read_text().splitlines()
+    called={};sets={}
+    for label,path in [(f'STAR_{m}',args.reference/m/'filtered') for m in ['Gene','GeneFull']]+[(f'replay_{m}',run/f'calling-replay-{m}') for m in ['Gene','GeneFull']]:
+        bc=path.joinpath('barcodes.tsv').read_text().splitlines();sets[label]=set(bc)
+        m=io.mmread(path/'matrix.mtx').tocsr()
+        called[label]={'called_nuclei':len(bc),'collapsed_umis_in_called_nuclei':int(m.sum()),
+                       'umis_per_called_nucleus':comparison.distribution(np.asarray(m.sum(axis=0)).ravel()),
+                       'genes_per_called_nucleus':comparison.distribution(np.asarray((m>0).sum(axis=0)).ravel())}
+    comparisons={}
+    for a,b in [('replay_Gene','replay_GeneFull'),('STAR_Gene','STAR_GeneFull'),('STAR_Gene','replay_Gene'),('STAR_GeneFull','replay_GeneFull')]:
+        x,y=sets[a],sets[b];comparisons[a+' to '+b]={'a_nuclei':len(x),'b_nuclei':len(y),'intersection':len(x&y),'union':len(x|y),
+            'a_only':len(x-y),'b_only':len(y-x),'jaccard':len(x&y)/len(x|y)}
+    (out/'nucleus-calling.json').write_text(json.dumps({'method':'STAR 2.7.11b EmptyDrops_CR default parameters; input each raw matrix separately','called':called,'comparisons':comparisons},indent=2)+'\n')
+    effects={}
+    for model in ['Gene','GeneFull']:
+        base,basegenes,_,_=comparison.load_selected(run/f'replay-v49-{model}',fixed)
+        for condition,otherpath in [('v32_to_v49',run/f'replay-v32-{model}-raw'),('v49_to_extended',run/f'replay-extended-{model}-raw')]:
+            other,othergenes,_,_=comparison.load_selected(otherpath,fixed)
+            ga=list(map(stable_id,basegenes));gb=list(map(stable_id,othergenes));union=sorted(set(ga)|set(gb))
+            ba=align(base,ga,union);ot=align(other,gb,union)
+            a,b=(ot,ba) if condition=='v32_to_v49' else (ba,ot)
+            effects[model+'/'+condition]=comparison.compare(a,b)
+            effects[model+'/'+condition]['gene_matching']='Ensembl accession without version, preserving _PAR_Y suffix'
+            effects[model+'/'+condition]['scope']='same 6460 Gene-called nuclei; replay of fixed annotation-free alignments'
+    (out/'annotation-effects.json').write_text(json.dumps(effects,indent=2)+'\n')
+    print(json.dumps({'calling':comparisons,'annotation_effects':{k:{name:v[name] for name in ['a_collapsed_umis','b_collapsed_umis','positive_count_difference_umis','negative_count_difference_umis','half_l1_over_a_umis']} for k,v in effects.items()}},indent=2))
+
+if __name__=='__main__':main()

--- a/scripts/validate-em-strands.py
+++ b/scripts/validate-em-strands.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Gene/GeneFull EM strand checks against STARsolo on synthetic ambiguous evidence.
+
+Requires STAR 2.7.11b and aie; writes a new directory only. Tests ordinary
+recovery EM independently of the STAR-style emission implementation.
+"""
+import argparse
+import json
+from pathlib import Path
+import random
+import subprocess
+
+
+def run(argv, log):
+    with log.open('w') as stream:
+        subprocess.run(list(map(str, argv)), stdout=stream, stderr=subprocess.STDOUT, check=True)
+
+
+def matrix(directory, filename):
+    genes = [s.split('\t')[0] for s in (directory / 'features.tsv').read_text().splitlines()]
+    rows = [s for s in (directory / filename).read_text().splitlines() if not s.startswith('%')]
+    assert list(map(int, rows[0].split()))[:2] == [len(genes), 1]
+    result = {}
+    for row in rows[1:]:
+        g, c, value = row.split()
+        if float(value):
+            result[genes[int(g) - 1]] = float(value)
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--aie', type=Path, required=True)
+    parser.add_argument('--star', type=Path, required=True)
+    parser.add_argument('--out', type=Path, required=True)
+    args = parser.parse_args()
+    args.aie = args.aie.resolve()
+    args.star = args.star.resolve()
+    out = args.out.resolve()
+    out.mkdir(parents=True, exist_ok=False)
+    rng = random.Random(714)
+    genome = ''.join(rng.choice('ACGT') for _ in range(6000))
+    # Two copies create real alternative placements with unique flanks.
+    genome = genome[:3000] + genome[2000:2060] + genome[3060:]
+    fasta = out / 'genome.fa'
+    fasta.write_text('>chr1\n' + genome + '\n')
+    annotation = [('A', '+', [(100, 200), (400, 500)]),
+                  ('B', '+', [(250, 300)]), ('C', '-', [(600, 700), (900, 1000)]),
+                  ('H', '+', [(710, 760)]), ('E', '+', [(2000, 2200)]),
+                  ('F', '+', [(3000, 3200)]), ('G', '-', [(2000, 2200)])]
+    gtf = out / 'genes.gtf'
+    gtf.write_text(''.join(
+        f'chr1\tfixture\texon\t{s+1}\t{e}\t.\t{strand}\t.\tgene_id "{gene}"; transcript_id "{gene}1"; gene_name "{gene}";\n'
+        for gene, strand, exons in annotation for s, e in exons))
+    barcode = 'ACGTACGTACGTACGT'
+    wl = out / 'barcodes.tsv'
+    wl.write_text(barcode + '\n')
+    umis = []
+    while len(umis) < 100:
+        u = ''.join(rng.choice('ACGT') for _ in range(12))
+        if all(sum(a != b for a, b in zip(u, v)) >= 3 for v in umis):
+            umis.append(u)
+    # Intronic, nested, antisense and mixed unique/multiple-placement classes.
+    specs = [(110, 40, 0), (210, 40, 1), (260, 35, 2), (620, 40, 3),
+             (710, 40, 4), (2080, 45, 5), (2085, 45, 6), (2090, 45, 7),
+             (3080, 45, 8), (2005, 45, 9), (2005, 45, 10),
+             (2080, 45, 11), (2005, 45, 11), (110, 40, 12), (260, 35, 12)]
+    # Both cDNA orientations get distinct tags. Repeated reads test class handling.
+    reads = [(genome[s:s+n], umis[u + 20 * rev], rev) for rev in [0, 1] for s, n, u in specs]
+    reads += [reads[9], reads[9], reads[0]]
+    rc = str.maketrans('ACGT', 'TGCA')
+    r1, r2 = out / 'r1.fq', out / 'r2.fq'
+    r1.write_text(''.join(f'@r{i}\n{barcode}{u}\n+\n' + 'I' * 28 + '\n'
+                          for i, (_, u, _) in enumerate(reads)))
+    r2.write_text(''.join(f'@r{i}\n{seq.translate(rc)[::-1] if rev else seq}\n+\n' + 'I' * len(seq) + '\n'
+                          for i, (seq, _, rev) in enumerate(reads)))
+    index = out / 'index'
+    index.mkdir()
+    run([args.star, '--runMode', 'genomeGenerate', '--runThreadN', '2', '--genomeDir', index,
+         '--genomeFastaFiles', fasta, '--sjdbGTFfile', gtf, '--sjdbOverhang', '44',
+         '--genomeSAindexNbases', '3', '--genomeChrBinNbits', '12',
+         '--outFileNamePrefix', str(out / 'index-')], out / 'index.log')
+    checks = []
+    for strand in ['Forward', 'Reverse', 'Unstranded']:
+        dest = out / strand
+        dest.mkdir()
+        run([args.star, '--genomeDir', index, '--runThreadN', '2', '--readFilesIn', r2, r1,
+             '--soloType', 'CB_UMI_Simple', '--soloCBwhitelist', wl, '--soloCBlen', '16',
+             '--soloUMIstart', '17', '--soloUMIlen', '12', '--soloBarcodeReadLength', '0',
+             '--soloFeatures', 'Gene', 'GeneFull', '--soloStrand', strand, '--soloMultiMappers', 'EM',
+             '--soloUMIdedup', '1MM_CR', '--soloUMIfiltering', 'MultiGeneUMI_CR', '--soloCellFilter', 'None',
+             '--outSAMtype', 'BAM', 'SortedByCoordinate', '--outSAMattributes', 'NH', 'HI', 'AS', 'nM', 'CR', 'CY', 'UR', 'UY',
+             '--outFilterMatchNmin', '20', '--outFilterScoreMinOverLread', '0', '--outFilterMatchNminOverLread', '0',
+             '--outFileNamePrefix', str(dest) + '/'], dest / 'star.log')
+        archive = dest / 'fixture.aie'
+        run([args.aie, 'ingest-archive', dest / 'Aligned.sortedByCoord.out.bam', '--whitelist', wl,
+             '--out', archive, '--zstd-level', '1'], dest / 'ingest.log')
+        for model in ['Gene', 'GeneFull']:
+            flags = ['--gene-full'] if model == 'GeneFull' else []
+            common = [args.aie, 'dev', 'em', archive, '--gtf', gtf, '--solo-strand', strand.lower(), *flags]
+            em = dest / f'{model}-star-em'
+            run([*common, '--star', '--emit', em, '--barcodes', wl], dest / f'{model}-star-em.log')
+            expected = matrix(dest / 'Solo.out' / model / 'raw', 'UniqueAndMult-EM.mtx')
+            unique = matrix(dest / 'Solo.out' / model / 'raw', 'matrix.mtx')
+            observed = matrix(em, 'UniqueAndMult-EM.mtx')
+            replay = dest / f'{model}-unique'
+            run([args.aie, 'replay-rows', archive, '--gtf', gtf, '--solo-strand', strand.lower(),
+                 '--barcodes', wl, '--out-dir', replay, *flags], dest / f'{model}-unique.log')
+            replay_unique = matrix(replay, 'matrix.mtx')
+            keys = expected.keys() | observed.keys() | unique.keys() | replay_unique.keys()
+            error = max((abs(expected.get(g, 0) - observed.get(g, 0)) for g in keys), default=0)
+            unique_differences = {g: replay_unique.get(g, 0) - unique.get(g, 0) for g in keys
+                                  if replay_unique.get(g, 0) != unique.get(g, 0)}
+            em_error = max((abs((expected.get(g, 0) - unique.get(g, 0)) -
+                                (observed.get(g, 0) - replay_unique.get(g, 0))) for g in keys), default=0)
+            # The Gene fixture intentionally includes a unique-gene weight tie. Existing
+            # replay keeps the lower gene id whereas STAR removes the tied UMI. Preserve
+            # and report that established unique-count difference; test EM separately.
+            assert unique_differences == ({'A': 2.0 if strand == 'Unstranded' else 1.0} if model == 'Gene' else {}), (strand, model, unique_differences)
+            # STAR prints six significant digits; aie prints six decimal places.
+            assert em_error <= 5e-5, (strand, model, expected, observed, em_error)
+            assert sum(expected.values()) > sum(unique.values()), 'fixture must exercise ambiguous EM'
+            metadata = json.loads((em / 'metadata.json').read_text())
+            assert metadata['counting_model'] == model and metadata['strand_policy'] == strand.lower()
+            outputs = []
+            for eager in [False, True]:
+                recovery = dest / f'{model}-recovery-{eager}'
+                run([*common, '--mask', '0', '--emit', recovery, '--barcodes', wl,
+                     *(['--eager'] if eager else ['--modes', 'pooled'])], dest / f'{model}-recovery-{eager}.log')
+                outputs.append(matrix(recovery, 'em.mtx'))
+                assert json.loads((recovery / 'metadata.json').read_text())['strand_policy'] == strand.lower()
+            assert outputs[0].keys() == outputs[1].keys()
+            assert all(abs(outputs[0][g] - outputs[1][g]) <= 1e-6 for g in outputs[0]), (strand, model, outputs)
+            metrics = dest / f'{model}-masked.json'
+            run([*common, '--mask', '0.5', '--eval-barcodes', wl, '--metrics-json', metrics], dest / f'{model}-masked.log')
+            selected = dest / f'{model}-selected.json'
+            run([*common, '--mask', '0.5', '--eval-barcodes', wl, '--modes', 'pooled', '--metrics-json', selected],
+                dest / f'{model}-selected.log')
+            full, one = json.loads(metrics.read_text()), json.loads(selected.read_text())
+            assert [m for m in full['modes'] if m['name'] == 'pooled'] == one['modes']
+            assert full['evaluation_counts'] == one['evaluation_counts']
+            checks.append({'model': model, 'strand': strand, 'star_max_absolute_error': error, 'em_increment_max_absolute_error': em_error,
+                           'unique_count_differences': unique_differences,
+                           'unique_umis': sum(unique.values()), 'unique_plus_em': sum(expected.values()),
+                           'pooled_raw_class_mass': sum(outputs[0].values()), 'evaluation_counts': full['evaluation_counts']})
+    (out / 'summary.json').write_text(json.dumps({'passed': True, 'checks': checks}, indent=2) + '\n')
+    print(f'{len(checks)} model/strand combinations passed STARsolo, packed/eager and mode-selection checks')
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/validate-genefull.py
+++ b/scripts/validate-genefull.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Synthetic STARsolo and representation checks; writes only a new output directory.
+
+Requires aie and STAR 2.7.11b. Uses deterministic synthetic sequence,
+not project data. Compare identical annotation-aware alignments first; the
+biological comparison separately measures annotation-free alignment replay.
+"""
+import argparse
+import json
+from pathlib import Path
+import random
+import subprocess
+
+
+def run(argv, log):
+    with log.open('w') as f:
+        subprocess.run(list(map(str, argv)), stdout=f, stderr=subprocess.STDOUT, check=True)
+
+
+def matrix(path):
+    genes=[line.split('\t')[0] for line in (path/'features.tsv').read_text().splitlines()]
+    barcodes=(path/'barcodes.tsv').read_text().splitlines()
+    rows=[line for line in (path/'matrix.mtx').read_text().splitlines() if not line.startswith('%')]
+    shape=list(map(int,rows[0].split()))
+    assert shape[:2]==[len(genes),len(barcodes)]
+    result={}
+    for row in rows[1:]:
+        g,c,n=map(int,row.split())
+        if n: result[(genes[g-1],barcodes[c-1])]=n
+    return result
+
+
+def main():
+    ap=argparse.ArgumentParser()
+    ap.add_argument('--aie',type=Path,required=True)
+    ap.add_argument('--star',type=Path,required=True)
+    ap.add_argument('--out',type=Path,required=True)
+    args=ap.parse_args()
+    out=args.out.resolve();out.mkdir(parents=True,exist_ok=False)
+    rng=random.Random(991)
+    genome=''.join(rng.choice('ACGT') for _ in range(6000))
+    # Canonical splice boundaries for A and C; D has disjoint isoforms.
+    for start,end in [(200,400),(700,900)]:
+        genome=genome[:start]+'GT'+genome[start+2:end-2]+'AG'+genome[end:]
+    fasta=out/'genome.fa';fasta.write_text('>chr1\n'+genome+'\n')
+    annotation=[('A','A1','+',[(100,200),(400,500)]),('B','B1','+',[(250,300)]),
+                ('C','C1','-',[(600,700),(900,1000)]),
+                ('D','D1','+',[(1200,1250)]),('D','D2','+',[(1500,1550)]),
+                ('E','E1','+',[(2000,2100)])]
+    gtf=out/'genes.gtf'
+    gtf.write_text(''.join(f'chr1\tfixture\texon\t{s+1}\t{e}\t.\t{strand}\t.\tgene_id "{g}"; transcript_id "{t}"; gene_name "{g}";\n'
+                           for g,t,strand,exons in annotation for s,e in exons))
+    cb='ACGTACGTACGTACGT';wl=out/'barcodes.tsv';wl.write_text(cb+'\n')
+    # Separate molecular tags (minimum Hamming distance >=3), plus one intended 1MM edge.
+    umis=[]
+    while len(umis)<30:
+        u=''.join(rng.choice('ACGT') for _ in range(12))
+        if all(sum(a!=b for a,b in zip(u,v))>=3 for v in umis): umis.append(u)
+    specs=[(110,50,False),(210,30,False),(260,30,False),(480,50,False),
+           (1000,50,False),(1300,50,False),(710,50,True),(620,50,True),
+           (2050,50,False),(350,30,False)]
+    reads=[(genome[s:s+n],umis[i],rev) for i,(s,n,rev) in enumerate(specs)]
+    reads.extend([(genome[150:200]+genome[400:450],umis[10],False),
+                  (genome[140:190]+genome[410:460],umis[11],False)])
+    # Repeated geometries on one molecule and a less abundant adjacent UMI.
+    reads.extend([(genome[110:160],umis[0],False)]*3)
+    last='A' if umis[0][-1]!='A' else 'C'
+    reads.append((genome[120:170],umis[0][:-1]+last,False))
+    r1=out/'r1.fq';r2=out/'r2.fq'
+    complement=str.maketrans('ACGT','TGCA')
+    r1.write_text(''.join(f'@r{i}\n{cb}{u}\n+\n'+('I'*28)+'\n' for i,(_,u,_) in enumerate(reads)))
+    r2.write_text(''.join(f'@r{i}\n{seq.translate(complement)[::-1] if rev else seq}\n+\n'+('I'*len(seq))+'\n' for i,(seq,_,rev) in enumerate(reads)))
+    index=out/'index';index.mkdir()
+    run([args.star,'--runMode','genomeGenerate','--runThreadN','2','--genomeDir',index,
+         '--genomeFastaFiles',fasta,'--sjdbGTFfile',gtf,'--sjdbOverhang','49',
+         '--genomeSAindexNbases','3','--genomeChrBinNbits','12','--outFileNamePrefix',str(out/'index-')],out/'index.log')
+    checks=[]
+    for strand in ['Forward','Reverse','Unstranded']:
+        star=out/strand;star.mkdir()
+        run([args.star,'--genomeDir',index,'--runThreadN','2','--readFilesIn',r2,r1,
+             '--soloType','CB_UMI_Simple','--soloCBwhitelist',wl,'--soloCBlen','16','--soloUMIstart','17','--soloUMIlen','12',
+             '--soloBarcodeReadLength','0','--soloFeatures','Gene','GeneFull','--soloStrand',strand,
+             '--soloUMIdedup','1MM_CR','--soloUMIfiltering','MultiGeneUMI_CR','--soloCellFilter','None',
+             '--outSAMtype','BAM','SortedByCoordinate','--outSAMattributes','NH','HI','AS','nM','CR','CY','UR','UY',
+             '--outFileNamePrefix',str(star)+'/', '--outFilterMatchNmin','20',
+             '--outFilterScoreMinOverLread','0','--outFilterMatchNminOverLread','0'],star/'command.log')
+        bam=star/'Aligned.sortedByCoord.out.bam';archive=star/'fixture.aie'
+        run([args.aie,'ingest-archive',bam,'--whitelist',wl,'--out',archive,'--zstd-level','1'],star/'ingest.log')
+        compiled=star/'genes.aic'
+        run([args.aie,'compile-annotation',gtf,'--out',compiled],star/'compile.log')
+        for model in ['Gene','GeneFull']:
+            expected=matrix(star/'Solo.out'/model/'raw')
+            variants=[('stream',archive,gtf,[]),('eager',archive,gtf,['--eager']),
+                      ('compiled',archive,compiled,[]),('bam',bam,gtf,['--from-bam','--whitelist',wl])]
+            outputs=[]
+            for name,source,anno,extra in variants:
+                dest=star/f'{model}-{name}';report=star/f'{model}-{name}.json'
+                run([args.aie,'replay-rows',source,'--gtf',anno,'--barcodes',wl,'--out-dir',dest,
+                     '--solo-strand',strand.lower(),'--report-format','json','--report-output',report,
+                     *(['--gene-full'] if model=='GeneFull' else []),*extra],star/f'{model}-{name}.log')
+                observed=matrix(dest)
+                assert observed==expected,(strand,model,name,observed,expected)
+                outputs.append(dest)
+                payload=json.loads(report.read_text());summary=payload['data']['summary']
+                stats=summary['assignment_statistics']
+                assert stats['assigned_molecule_records']<=stats['molecule_records']
+                assert stats['assigned_representative_rows']<=stats['representative_rows']
+                assert stats['assigned_umi_classes']<=stats['umi_classes']
+                assert summary['assigned_molecules']==stats['assigned_molecule_records']
+                metadata=json.loads((dest/'metadata.json').read_text())
+                assert metadata['provenance']['parameters']['counting_model']==model
+                checks.append({'strand':strand,'model':model,'input':name,'umis':sum(observed.values()),'statistics':stats})
+            for dest in outputs[1:]:
+                for file in ['matrix.mtx','features.tsv','barcodes.tsv']:
+                    assert (dest/file).read_bytes()==(outputs[0]/file).read_bytes()
+        for incompatible in ['--velocity','--audit-multigene']:
+            result=subprocess.run([str(args.aie),'replay-rows',str(archive),'--gtf',str(gtf),'--barcodes',str(wl),
+                                   '--out-dir',str(star/'must-not-exist'),'--gene-full',incompatible],capture_output=True)
+            assert result.returncode!=0 and b'cannot be used with' in result.stderr
+            assert not (star/'must-not-exist').exists()
+    (out/'summary.json').write_text(json.dumps({'checks':checks,'passed':True},indent=2)+'\n')
+    print(f'{len(checks)} STARsolo/representation comparisons passed')
+
+if __name__=='__main__': main()


### PR DESCRIPTION
Prepare Gravlax 0.2.2 with intron-inclusive GeneFull replay and strand-aware EM over existing archives. Recovery EM and STAR-style EM now support GeneFull with forward, reverse, and unstranded libraries. Default Gene/forward counting and existing archive and compiled-annotation encodings are preserved.

## Changes

- Add GeneFull replay for archive/BAM input, streaming/eager execution, compiled annotations, and the Python client, with counting-model provenance.
- Apply the selected counting model and strand consistently to unique and ambiguous EM evidence.
- Add independent evaluation-barcode and inference-mode selection while preserving full-input prior fitting and retained models' results.
- Spill EM support arrays according to actual retained candidate volume and expose `--support-memory-mib`; this is a support-storage budget, not a whole-process memory cap.
- Use direct aligned-block queries and separate strand indexes, with measured performance tradeoffs documented.
- Coordinate Rust, Python, documentation, and conda versions at **0.2.2**, and add release notes covering compatibility, counting units, validation, and optimizations.

## Reporting compatibility

`replay-rows` changes the meaning of `assigned_molecules`: it previously counted assigned representative rows and now counts molecule records with at least one uniquely assigned representative. It aliases `assignment_statistics.assigned_molecule_records`, whose denominator is `assignment_statistics.molecule_records`.

Consumers needing the previous row count should use `assignment_statistics.assigned_representative_rows`, with `assignment_statistics.representative_rows` as the denominator. Assignment statistics cover the full consumed input and remain distinct from collapsed-UMI matrix counts. This correction also applies to default Gene replay; it can change the reported number while leaving the count matrix identical. Existing `.aie` archives, including legacy v1, and `.aic` annotations need no migration.

## Validation

- 459 Rust tests passed, with three pre-existing ignored tests; 92 Python client tests and 43 packaging tests passed.
- Release package dry runs, version/package-graph and committed-history checks passed; the 32-page documentation site built successfully.
- The 0.2.2 release binary passed all six EM model/strand combinations and 24 STARsolo/replay representation comparisons.
- Fixed-nucleus brain GeneFull EM JSON matches the preceding validated candidate exactly; all four retained model results and coverage counters match the nine-mode baseline. The original 6,460 nuclei remain fixed, prior fitting uses all archive barcodes, and accuracy is conditional on 156,884 evaluable raw UMI classes before one-mismatch collapse. Nucleus-calling effects are assessed separately.
- Default Gene replay and EM regressions, forced-spill equivalence, and interleaved optimization benchmarks are documented in [the validation report](https://github.com/COMBINE-lab/gravlax/blob/dabf745b8195b781f1b0f13871ab3239d697942c/docs/genefull-em-strands-optimization.md). The existing Gene UMI tie-breaking difference from STARsolo is preserved and disclosed.

This PR prepares the version bump. Release tagging and publication follow merge and the required native portability checks.
