### PR TITLE
Chemistry-derived sjdbOverhang and readable alignment provenance in inspect-archive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ This file records user-visible changes in each Gravlax release.
   `--alignment-annotation` declarations, so the seed and discovery mode are
   recorded in archive provenance. No archive-format change.
 
+- `aie ingest recipe` now derives the default `--sjdbOverhang` from
+  `--chemistry` instead of using a fixed 100: 90 for 10x 3' v3/v3.1 (91 bp cDNA
+  reads) and 97 for 10x 3' v2 (98 bp cDNA reads), following STAR's read length
+  minus one rule. `--sjdb-overhang <N>` still overrides it, and the flag is
+  still emitted only with `--junction-seed`.
+
+- `aie inspect-archive` now shows alignment provenance in its human-readable
+  output. The legacy text summary and the `--format text`/`--format tsv`
+  reports list the provenance status, junction discovery mode, junction
+  catalogue role, digest and data-row count, alignment annotation digest and
+  locator, alignment chemistry, index identity, and aligner program versions.
+  Archives without a manifest report a single line saying none is recorded.
+  The `--json` output is unchanged; `--format json` gains the same rows as an
+  `alignment_provenance` table. No archive-format change.
+
 ## [0.2.2] - 2026-09-10
 
 ### Compatibility and assignment statistics

--- a/crates/aie/src/archivecmd.rs
+++ b/crates/aie/src/archivecmd.rs
@@ -4272,6 +4272,7 @@ const SEAL_REPORT_SCHEMA: &str = "gravlax.archive.seal-report.v1";
 const INSPECT_REPORT_SCHEMA: &str = "gravlax.archive.inspect-report.v1";
 const STAMP_REPORT_SCHEMA: &str = "gravlax.archive.stamp-genome-report.v1";
 const SECTION_TABLE_SCHEMA: &str = "gravlax.archive.section-accounting.v1";
+const ALIGNMENT_PROVENANCE_TABLE_SCHEMA: &str = "gravlax.archive.alignment-provenance-summary.v1";
 const REPLAY_FILE_TABLE_SCHEMA: &str = "gravlax.archive.replay-artifact-files.v1";
 const REPLAY_MEX_SCHEMA: &str = "gravlax.replay.mex-artifact.v1";
 
@@ -4840,6 +4841,149 @@ fn report_context(
         warnings,
         ..ResultContext::default()
     }
+}
+
+fn provenance_status_label(status: ProvenanceStatus) -> &'static str {
+    match status {
+        ProvenanceStatus::VerifiedFromConsumedBytes => "verified-from-consumed-bytes",
+        ProvenanceStatus::VerifiedBamHeader => "verified-bam-header",
+        ProvenanceStatus::DeclaredByCaller => "declared-by-caller",
+        ProvenanceStatus::Unspecified => "unspecified",
+    }
+}
+
+fn junction_discovery_label(mode: JunctionDiscoveryMode) -> &'static str {
+    match mode {
+        JunctionDiscoveryMode::Unspecified => "unspecified",
+        JunctionDiscoveryMode::OnePass => "one-pass",
+        JunctionDiscoveryMode::PerLibraryTwoPass => "per-library-two-pass",
+        JunctionDiscoveryMode::FrozenCatalogue => "frozen-catalogue",
+    }
+}
+
+fn junction_catalogue_role_label(role: JunctionCatalogueRole) -> &'static str {
+    match role {
+        JunctionCatalogueRole::PerLibraryPass1 => "per-library-pass1",
+        JunctionCatalogueRole::FrozenExternal => "frozen-external",
+    }
+}
+
+/// Single clear line used wherever an archive records no alignment provenance at all.
+const NO_ALIGNMENT_PROVENANCE: &str =
+    "none recorded; junction discovery, catalogue, annotation and aligner identity are unknown";
+
+/// Flatten the alignment-provenance manifest into ordered field/value pairs so that the legacy
+/// text summary and the uniform text/tsv reports describe provenance identically. An archive
+/// without a manifest yields exactly one row stating that none is recorded.
+fn alignment_provenance_rows(
+    provenance: Option<&AlignmentProvenanceManifest>,
+) -> Vec<(&'static str, String)> {
+    let Some(provenance) = provenance else {
+        return vec![("status", NO_ALIGNMENT_PROVENANCE.to_string())];
+    };
+    let alignment = &provenance.alignment;
+    let mut rows = vec![
+        (
+            "status",
+            format!(
+                "{} ({})",
+                provenance_status_label(alignment.status),
+                provenance.schema
+            ),
+        ),
+        (
+            "junction_discovery",
+            junction_discovery_label(alignment.junction_discovery).to_string(),
+        ),
+    ];
+    match &alignment.junction_catalogue {
+        Some(catalogue) => {
+            rows.push((
+                "junction_catalogue_role",
+                format!(
+                    "{} (section {})",
+                    junction_catalogue_role_label(catalogue.role),
+                    catalogue.section
+                ),
+            ));
+            rows.push((
+                "junction_catalogue_blake3",
+                format!(
+                    "{}:{}",
+                    catalogue.identity.scheme, catalogue.identity.blake3
+                ),
+            ));
+            rows.push((
+                "junction_catalogue_data_rows",
+                catalogue.data_rows.to_string(),
+            ));
+        }
+        None => rows.push(("junction_catalogue", "none recorded".to_string())),
+    }
+    match &alignment.alignment_annotation {
+        Some(annotation) => {
+            rows.push((
+                "alignment_annotation_blake3",
+                format!(
+                    "{}:{}",
+                    annotation.identity.scheme, annotation.identity.blake3
+                ),
+            ));
+            rows.push(("alignment_annotation_locator", annotation.locator.clone()));
+        }
+        None => rows.push(("alignment_annotation", "none declared".to_string())),
+    }
+    rows.push((
+        "alignment_chemistry",
+        match &alignment.chemistry {
+            Some(chemistry) => format!(
+                "{chemistry} ({})",
+                provenance_status_label(alignment.chemistry_status)
+            ),
+            None => "unspecified".to_string(),
+        },
+    ));
+    rows.push((
+        "index_identity",
+        match &alignment.index_identity {
+            Some(identity) => format!(
+                "{identity} ({})",
+                provenance_status_label(alignment.index_identity_status)
+            ),
+            None => "unspecified".to_string(),
+        },
+    ));
+    let programs = alignment
+        .programs
+        .iter()
+        .map(|program| {
+            format!(
+                "{} {}",
+                program.name.as_deref().unwrap_or(program.id.as_str()),
+                program.version.as_deref().unwrap_or("version-unspecified")
+            )
+        })
+        .collect::<Vec<_>>();
+    rows.push((
+        "aligner_programs",
+        if programs.is_empty() {
+            "none recorded in the BAM header".to_string()
+        } else {
+            programs.join("; ")
+        },
+    ));
+    rows
+}
+
+fn alignment_provenance_table_schema() -> std::result::Result<TableSchema, OutputError> {
+    TableSchema::new(
+        ALIGNMENT_PROVENANCE_TABLE_SCHEMA,
+        vec![
+            Field::new("field", DataType::String),
+            Field::new("value", DataType::String),
+        ],
+    )?
+    .with_semantics(TableSemantics::new(RowSemantics::Set).with_key(["field"]))
 }
 
 fn section_table_schema() -> std::result::Result<TableSchema, OutputError> {
@@ -5607,6 +5751,8 @@ pub fn run_inspect_archive(args: InspectArchiveArgs) -> Result<()> {
             Vec::new(),
         );
         let schema = section_table_schema()?;
+        let provenance_schema = alignment_provenance_table_schema()?;
+        let provenance_rows = alignment_provenance_rows(alignment_provenance.as_ref());
         let format = args.format.expect("uniform inspect format preflighted");
         write_uniform_output(format, args.output.as_deref(), |writer| {
             let mut bundle = StreamingBundleWriter::new_with_summary(
@@ -5616,6 +5762,17 @@ pub fn run_inspect_archive(args: InspectArchiveArgs) -> Result<()> {
                 &context,
                 &summary,
             )?;
+            // Emitted before the section accounting so that the text and tsv renderings put the
+            // readable provenance next to the summary rather than after a long section table.
+            bundle.write_table("alignment_provenance", &provenance_schema, None, |table| {
+                for (field, value) in &provenance_rows {
+                    table.write_row_with(|row| {
+                        row.string(field)?;
+                        row.string(value)
+                    })?;
+                }
+                Ok(())
+            })?;
             bundle.write_table("sections", &schema, None, |table| {
                 for (name, _, raw, compressed) in reader.entries() {
                     table.write_row_with(|row| {
@@ -5650,16 +5807,14 @@ pub fn run_inspect_archive(args: InspectArchiveArgs) -> Result<()> {
         match (&alignment_provenance, molecular_evidence_schema) {
             (Some(provenance), Some(schema)) => {
                 println!("molecular evidence schema: {schema}");
-                println!(
-                    "alignment provenance: {} ({:?}, {:?})",
-                    ALIGNMENT_PROVENANCE_SCHEMA,
-                    provenance.alignment.junction_discovery,
-                    provenance.alignment.status
-                );
+                println!("alignment provenance: {ALIGNMENT_PROVENANCE_SCHEMA}");
+                for (field, value) in alignment_provenance_rows(Some(provenance)) {
+                    println!("  {field}: {value}");
+                }
             }
             _ => {
                 println!("molecular evidence schema: unavailable (legacy archive)");
-                println!("alignment provenance: unavailable; junction discovery is unknown");
+                println!("alignment provenance: {NO_ALIGNMENT_PROVENANCE}");
             }
         }
         if let Some(tails) = &terminal_tail {

--- a/crates/aie/src/ingestcmd.rs
+++ b/crates/aie/src/ingestcmd.rs
@@ -56,6 +56,15 @@ impl Chemistry {
         }
     }
 
+    /// STAR's `--sjdbOverhang` rule: the cDNA read length minus one. 10x 3' v2 cDNA reads are
+    /// 98 bp; 10x 3' v3/v3.1 cDNA reads are 91 bp.
+    fn sjdb_overhang(self) -> usize {
+        match self {
+            Self::TenX3pV2 => 97,
+            Self::TenX3pV3 => 90,
+        }
+    }
+
     fn default_whitelist(self) -> &'static str {
         match self {
             Self::TenX3pV2 => "737K-august-2016.txt",
@@ -134,10 +143,11 @@ struct RecipeArgs {
     #[arg(long, value_name = "FILE")]
     junction_seed: Option<PathBuf>,
 
-    /// STAR `--sjdbOverhang` used when a seed is inserted at mapping time (cDNA read length
-    /// minus one; STAR's own default is 100). Only emitted with `--junction-seed`.
-    #[arg(long, default_value_t = 100, value_name = "N")]
-    sjdb_overhang: usize,
+    /// STAR `--sjdbOverhang` used when a seed is inserted at mapping time. Defaults to the
+    /// selected chemistry's cDNA read length minus one (90 for 10x 3' v3/v3.1, 97 for 10x 3' v2).
+    /// Only emitted with `--junction-seed`.
+    #[arg(long, value_name = "N")]
+    sjdb_overhang: Option<usize>,
 
     /// Omit per-library two-pass junction discovery (`--twopassMode Basic`). Off by default.
     #[arg(long)]
@@ -799,7 +809,10 @@ fn run_recipe(args: RecipeArgs) -> Result<()> {
     let whitelist = args
         .whitelist
         .unwrap_or_else(|| PathBuf::from(args.chemistry.default_whitelist()));
-    if args.junction_seed.is_some() && args.sjdb_overhang == 0 {
+    let sjdb_overhang = args
+        .sjdb_overhang
+        .unwrap_or_else(|| args.chemistry.sjdb_overhang());
+    if args.junction_seed.is_some() && sjdb_overhang == 0 {
         bail!("--sjdb-overhang must be at least 1");
     }
     println!(
@@ -811,8 +824,10 @@ fn run_recipe(args: RecipeArgs) -> Result<()> {
     );
     if let Some(seed) = &args.junction_seed {
         println!(
-            "# Optional junction seeding: {} is inserted at mapping time. Gene models are still deferred to replay; the seed and its digest are recorded in the archive at ingest.",
-            shell_quote(seed)
+            "# Optional junction seeding: {} is inserted at mapping time with --sjdbOverhang {} ({} cDNA read length minus one). Gene models are still deferred to replay; the seed and its digest are recorded in the archive at ingest.",
+            shell_quote(seed),
+            sjdb_overhang,
+            args.chemistry.label()
         );
     }
     if args.one_pass {
@@ -826,7 +841,7 @@ fn run_recipe(args: RecipeArgs) -> Result<()> {
     println!("  --genomeDir {} \\", shell_quote(&args.genome_dir));
     if let Some(seed) = &args.junction_seed {
         println!("  --sjdbFileChrStartEnd {} \\", shell_quote(seed));
-        println!("  --sjdbOverhang {} \\", args.sjdb_overhang);
+        println!("  --sjdbOverhang {sjdb_overhang} \\");
     }
     println!(
         "  --readFilesIn {} {} \\",

--- a/crates/aie/tests/archive_uniform_io.rs
+++ b/crates/aie/tests/archive_uniform_io.rs
@@ -173,7 +173,7 @@ fn inspect_and_seal_reports_are_typed_atomic_and_legacy_exact() {
 native identity: aie-directory-root-v2:{root}\n\
 encoded sections: aie-encoded-sections-v1:{encoded}\n\
 molecular evidence schema: unavailable (legacy archive)\n\
-alignment provenance: unavailable; junction discovery is unknown\n\
+alignment provenance: none recorded; junction discovery, catalogue, annotation and aligner identity are unknown\n\
 terminal tails: unavailable (extraction rule was not recorded as evaluated)\n\
 genome reference binding: legacy/unattributed\n\
 verified directory/root; payloads will be verified when selected\n",
@@ -197,10 +197,24 @@ verified directory/root; payloads will be verified when selected\n",
         value["data"]["summary"]["archive"]["native_identity"]["blake3"],
         root
     );
-    assert_eq!(
-        value["data"]["tables"][0]["rows"].as_array().unwrap().len(),
-        3
-    );
+    let table = |name: &str| {
+        value["data"]["tables"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|table| table["name"] == name)
+            .unwrap()
+            .clone()
+    };
+    assert_eq!(table("sections")["rows"].as_array().unwrap().len(), 3);
+    // A legacy archive records no provenance at all: exactly one row says so.
+    let provenance_rows = table("alignment_provenance")["rows"].clone();
+    assert_eq!(provenance_rows.as_array().unwrap().len(), 1);
+    assert_eq!(provenance_rows[0][0], "status");
+    assert!(provenance_rows[0][1]
+        .as_str()
+        .unwrap()
+        .starts_with("none recorded;"));
 
     let failed = run_failing(
         Command::new(bin)
@@ -320,7 +334,10 @@ fn artifact_report_preflight_rejects_normalized_destination_aliases() {
         );
         assert!(String::from_utf8_lossy(&symlinked.stderr)
             .contains("operation report path must differ from the primary artifact path"));
-        assert!(!primary.exists(), "symlink alias rejection must precede ingest");
+        assert!(
+            !primary.exists(),
+            "symlink alias rejection must precede ingest"
+        );
     }
 }
 

--- a/crates/aie/tests/ux_cli.rs
+++ b/crates/aie/tests/ux_cli.rs
@@ -237,7 +237,7 @@ fn recipe_junction_seed_and_one_pass_are_optional_and_declared() {
             "--junction-seed",
             "v32.junctions.tab",
             "--sjdb-overhang",
-            "90",
+            "74",
             "--one-pass",
         ])
         .output()
@@ -245,7 +245,7 @@ fn recipe_junction_seed_and_one_pass_are_optional_and_declared() {
     assert!(output.status.success());
     let recipe = String::from_utf8_lossy(&output.stdout);
     assert!(recipe.contains("--sjdbFileChrStartEnd v32.junctions.tab"));
-    assert!(recipe.contains("--sjdbOverhang 90"));
+    assert!(recipe.contains("--sjdbOverhang 74"));
     assert!(!recipe.contains("--twopassMode"));
     assert!(!recipe.contains("--sjdbGTFfile"));
     assert!(recipe.contains(
@@ -269,6 +269,39 @@ fn recipe_junction_seed_and_one_pass_are_optional_and_declared() {
     assert!(recipe.contains(
         "--junction-discovery per-library-two-pass --junction-catalogue align/_STARpass1/SJ.out.tab --alignment-annotation v32.junctions.tab"
     ));
+}
+
+#[test]
+fn recipe_sjdb_overhang_defaults_to_the_chemistry_cdna_read_length() {
+    // STAR's rule is the cDNA read length minus one: 91 bp for 10x 3' v3/v3.1, 98 bp for v2.
+    for (chemistry, overhang) in [("10x-3p-v3", "90"), ("10x-3p-v2", "97")] {
+        let output = Command::new(env!("CARGO_BIN_EXE_aie"))
+            .args([
+                "ingest",
+                "recipe",
+                "--chemistry",
+                chemistry,
+                "--junction-seed",
+                "v32.junctions.tab",
+            ])
+            .output()
+            .unwrap();
+        assert!(output.status.success());
+        let recipe = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            recipe.contains(&format!("--sjdbOverhang {overhang}")),
+            "{chemistry} recipe did not default --sjdbOverhang to {overhang}: {recipe}"
+        );
+        assert!(!recipe.contains("--sjdbOverhang 100"));
+    }
+
+    // Without a seed the recipe still emits no junction flags at all.
+    let output = Command::new(env!("CARGO_BIN_EXE_aie"))
+        .args(["ingest", "recipe", "--chemistry", "10x-3p-v3"])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert!(!String::from_utf8_lossy(&output.stdout).contains("--sjdbOverhang"));
 }
 
 #[test]
@@ -313,6 +346,51 @@ fn junctions_command_writes_star_seed_format() {
         .unwrap();
     assert!(!output.status.success());
     assert!(String::from_utf8_lossy(&output.stderr).contains("refusing to overwrite"));
+}
+
+/// Same single-record fixture as [`write_ingest_bam`], plus the `@PG` line an aligner leaves
+/// behind, so provenance rendering has a program name and version to show.
+fn write_ingest_bam_with_aligner(path: &Path) {
+    use noodles_sam::header::record::value::map::{program::tag as program_tag, Program};
+
+    let header = sam::Header::builder()
+        .add_reference_sequence(
+            "chr1",
+            Map::<ReferenceSequence>::new(NonZero::new(10_000).unwrap()),
+        )
+        .add_program(
+            "STAR",
+            Map::<Program>::builder()
+                .insert(program_tag::NAME, "STAR")
+                .insert(program_tag::VERSION, "2.7.11b")
+                .build()
+                .unwrap(),
+        )
+        .build();
+    let data: Data = [
+        (Tag::new(b'C', b'R'), Value::from("AAAAAAAAAAAAAAAA")),
+        (Tag::new(b'C', b'Y'), Value::from("IIIIIIIIIIIIIIII")),
+        (Tag::new(b'U', b'R'), Value::from("ACGTACGTACGT")),
+        (Tag::ALIGNMENT_HIT_COUNT, Value::from(1u8)),
+    ]
+    .into_iter()
+    .collect();
+    let cigar: Cigar = [Op::new(Kind::Match, 50)].into_iter().collect();
+    let record = RecordBuf::builder()
+        .set_name("read-1")
+        .set_flags(Flags::empty())
+        .set_reference_sequence_id(0)
+        .set_alignment_start(Position::try_from(101).unwrap())
+        .set_cigar(cigar)
+        .set_sequence(Sequence::from(vec![b'A'; 50]))
+        .set_quality_scores(QualityScores::from(vec![30; 50]))
+        .set_data(data)
+        .build();
+    let file = std::fs::File::create(path).unwrap();
+    let mut writer = bam::io::Writer::new(file);
+    writer.write_header(&header).unwrap();
+    writer.write_alignment_record(&header, &record).unwrap();
+    writer.try_finish().unwrap();
 }
 
 fn write_ingest_bam(path: &Path) {
@@ -390,6 +468,117 @@ fn write_broken_multimap_bam(path: &Path) {
     writer.write_alignment_record(&header, &primary).unwrap();
     writer.write_alignment_record(&header, &secondary).unwrap();
     writer.try_finish().unwrap();
+}
+
+#[test]
+fn inspect_archive_text_summary_shows_alignment_provenance() {
+    let scratch = Scratch::new();
+    let bam = scratch.0.join("input.bam");
+    let whitelist = scratch.0.join("whitelist.txt");
+    let catalogue = scratch.0.join("frozen.sjdb.tab");
+    let annotation = scratch.0.join("alignment.sjdb.tab");
+    let archive = scratch.0.join("provenance.aie");
+    write_ingest_bam_with_aligner(&bam);
+    std::fs::write(&whitelist, "AAAAAAAAAAAAAAAA\n").unwrap();
+    std::fs::write(
+        &catalogue,
+        "# frozen junction catalogue\nchr1\t120\t140\t1\nchr1\t220\t240\t1\n",
+    )
+    .unwrap();
+    std::fs::write(&annotation, "chr1\t120\t140\t1\n").unwrap();
+
+    let ingest = Command::new(env!("CARGO_BIN_EXE_aie"))
+        .args(["ingest-archive"])
+        .arg(&bam)
+        .arg("--whitelist")
+        .arg(&whitelist)
+        .arg("--out")
+        .arg(&archive)
+        .args([
+            "--zstd-level",
+            "1",
+            "--junction-discovery",
+            "frozen-catalogue",
+        ])
+        .arg("--junction-catalogue")
+        .arg(&catalogue)
+        .arg("--alignment-annotation")
+        .arg(&annotation)
+        .args(["--alignment-chemistry", "10x-3p-v3"])
+        .args(["--alignment-index-identity", "star-index:fixture-v1"])
+        .output()
+        .unwrap();
+    assert!(
+        ingest.status.success(),
+        "ingest failed: {}",
+        String::from_utf8_lossy(&ingest.stderr)
+    );
+
+    // The digests shown in the human-readable summaries must be the ones the manifest records.
+    let json = Command::new(env!("CARGO_BIN_EXE_aie"))
+        .args(["inspect-archive"])
+        .arg(&archive)
+        .arg("--json")
+        .output()
+        .unwrap();
+    assert!(json.status.success());
+    let value: serde_json::Value = serde_json::from_slice(&json.stdout).unwrap();
+    let alignment = &value["molecular_evidence"]["alignment_provenance"]["alignment"];
+    let catalogue_digest = alignment["junction_catalogue"]["identity"]["blake3"]
+        .as_str()
+        .unwrap()
+        .to_owned();
+    let annotation_digest = alignment["alignment_annotation"]["identity"]["blake3"]
+        .as_str()
+        .unwrap()
+        .to_owned();
+    assert_ne!(catalogue_digest, annotation_digest);
+
+    let legacy = Command::new(env!("CARGO_BIN_EXE_aie"))
+        .args(["inspect-archive"])
+        .arg(&archive)
+        .output()
+        .unwrap();
+    assert!(legacy.status.success());
+    let text = String::from_utf8_lossy(&legacy.stdout).into_owned();
+    for expected in [
+        "alignment provenance: gravlax.alignment-provenance.v1",
+        "junction_discovery: frozen-catalogue",
+        "junction_catalogue_role: frozen-external",
+        "junction_catalogue_data_rows: 2",
+        "alignment_chemistry: 10x-3p-v3",
+        "index_identity: star-index:fixture-v1",
+        "aligner_programs: STAR 2.7.11b",
+    ] {
+        assert!(text.contains(expected), "missing {expected:?} in:\n{text}");
+    }
+    assert!(text.contains(&format!(
+        "junction_catalogue_blake3: full-file-blake3-v1:{catalogue_digest}"
+    )));
+    assert!(text.contains(&format!(
+        "alignment_annotation_blake3: full-file-blake3-v1:{annotation_digest}"
+    )));
+    assert!(text.contains(&format!(
+        "alignment_annotation_locator: {}",
+        annotation.display()
+    )));
+    assert!(!text.contains("alignment provenance: none recorded"));
+
+    for format in ["text", "tsv"] {
+        let uniform = Command::new(env!("CARGO_BIN_EXE_aie"))
+            .args(["inspect-archive"])
+            .arg(&archive)
+            .args(["--format", format])
+            .output()
+            .unwrap();
+        assert!(uniform.status.success());
+        let rendered = String::from_utf8_lossy(&uniform.stdout).into_owned();
+        let separator = if format == "tsv" { "\t" } else { " | " };
+        assert!(rendered.contains(&format!("junction_discovery{separator}frozen-catalogue")));
+        assert!(rendered.contains(&format!(
+            "junction_catalogue_blake3{separator}full-file-blake3-v1:{catalogue_digest}"
+        )));
+    }
 }
 
 #[test]

--- a/docs/src/content/docs/cli/ingest.md
+++ b/docs/src/content/docs/cli/ingest.md
@@ -39,7 +39,7 @@ recipe states this because a command cannot prove it from the directory name.
 | `--threads <N>` | `24` | STAR worker threads |
 | `--plain-fastq` | off | Treat inputs as uncompressed FASTQ and omit `zcat` |
 | `--junction-seed <FILE>` | off | Insert a fixed splice-junction list (STAR `--sjdbFileChrStartEnd` format) at mapping time; see below |
-| `--sjdb-overhang <N>` | `100` | STAR `--sjdbOverhang` emitted with `--junction-seed`; set to the cDNA read length minus one |
+| `--sjdb-overhang <N>` | chemistry-derived (`90` for 10x 3' v3/v3.1, `97` for 10x 3' v2) | STAR `--sjdbOverhang` emitted with `--junction-seed`: the cDNA read length minus one. Override only for non-standard read lengths |
 | `--one-pass` | off | Omit `--twopassMode Basic`, so junctions come only from the aligner's own detection and any seed |
 
 ## Optional junction seeding and one-pass alignment
@@ -57,8 +57,13 @@ derived from any GTF or compiled annotation:
 
 ```sh
 aie ingest junctions --gtf gencode.v32.annotation.gtf --out v32.junctions.tab
-aie ingest recipe --chemistry 10x-3p-v3 --junction-seed v32.junctions.tab --sjdb-overhang 90
+aie ingest recipe --chemistry 10x-3p-v3 --junction-seed v32.junctions.tab
 ```
+
+`--sjdbOverhang` follows STAR's rule of the cDNA read length minus one and is
+derived from `--chemistry`: 90 for 10x 3' v3/v3.1 (91 bp cDNA reads) and 97 for
+10x 3' v2 (98 bp cDNA reads). Pass `--sjdb-overhang <N>` to override it when a
+library was sequenced at a non-standard read length.
 
 The seed file has one junction per line: chromosome, 1-based inclusive intron
 start and end, and strand. With `--one-pass`, only the seed and the aligner's


### PR DESCRIPTION
Builds on #6 (`ingest-junction-seed`). **Please retarget this PR to `main` once #6 merges.**

## 1. `--sjdb-overhang` defaults from `--chemistry`

`aie ingest recipe` hardcoded STAR's own default of 100. STAR's rule is the cDNA read length minus one, so the default is now derived from the selected chemistry:

| chemistry | cDNA read | `--sjdbOverhang` |
| --- | --- | --- |
| `10x-3p-v3` (v3/v3.1) | 91 bp | 90 |
| `10x-3p-v2` | 98 bp | 97 |

`--sjdb-overhang <N>` remains an explicit override for non-standard read lengths, and `--sjdbOverhang` is still emitted only with `--junction-seed`. The recipe's comment line now names the resolved value and where it came from. Help text and the docs table in `docs/src/content/docs/cli/ingest.md` are updated; the `ux_cli` seeding test now passes a non-default override (74) and a new test checks the per-chemistry default and that no seed still means no `--sjdbOverhang`.

## 2. Alignment provenance in `aie inspect-archive` text/tsv

The manifest was only visible in JSON. A single flattening helper now feeds both the legacy text summary and a new `alignment_provenance` key/value table emitted first in the uniform `--format text`/`tsv`/`json` bundle, so all human-readable renderings agree. Surfaced: provenance status, junction discovery mode, junction catalogue role/digest/data-row count, alignment annotation digest and locator, alignment chemistry, index identity, and the aligner programs read from the BAM header. Archives with no manifest print one line saying none is recorded.

```
$ aie inspect-archive d0-v32-1pass.aie
d0-v32-1pass.aie: archive v2 with 1129 sections and 110403101 bytes
native identity: aie-directory-root-v2:d7460c6dad202ef23ff90723eaae9fc472b90ceb58d298aabfd3827d04028907
encoded sections: aie-encoded-sections-v1:d3879947779dae5ce8191f43d52c978357d43915e0ce6a168f79c67a74eb3b13
molecular evidence schema: gravlax.molecular-evidence.v2
alignment provenance: gravlax.alignment-provenance.v1
  status: declared-by-caller (gravlax.alignment-provenance.v1)
  junction_discovery: frozen-catalogue
  junction_catalogue_role: frozen-external (section alignment.junction-catalogue)
  junction_catalogue_blake3: full-file-blake3-v1:1f28843316123069678cd58f201e1562e1503117497231b1aaa1da1c416214c4
  junction_catalogue_data_rows: 382880
  alignment_annotation_blake3: full-file-blake3-v1:1f28843316123069678cd58f201e1562e1503117497231b1aaa1da1c416214c4
  alignment_annotation_locator: .../junction-seeded-ingest/v32.sjdb.tab
  alignment_chemistry: 10x-3p-v3 (declared-by-caller)
  index_identity: .../ref/star-base (annotation-free STAR 2.7.11b index; seed inserted at mapping, sjdbOverhang 90) (declared-by-caller)
  aligner_programs: STAR 2.7.11b
terminal tails: unavailable (extraction rule was not recorded as evaluated)
genome reference binding: unavailable
verified directory/root; payloads will be verified when selected
```

Verified manually against `d0-v32-1pass.aie` (frozen-catalogue), `d0-v32-2pass.aie` (per-library-two-pass, distinct pass-1 catalogue digest and 123035 rows), and the legacy `d0.aie`, which reports `alignment provenance: none recorded; junction discovery, catalogue, annotation and aligner identity are unknown`.

New `ux_cli` test ingests a tiny synthetic BAM (with a `@PG` line) using `--junction-discovery frozen-catalogue --junction-catalogue --alignment-annotation`, cross-checks the digests shown in text/tsv against the ones in the JSON manifest, and asserts the mode. `archive_uniform_io`'s exact legacy-text assertion and its table lookup are updated (tables are now looked up by name rather than by index).

`--json` output is unchanged. No archive or annotation format change; no version bump. CHANGELOG has an `## Unreleased` entry for both changes.

## Checks

- `cargo test -p gravlax`: all suites pass (`251 passed` unit; `9 passed` ux_cli; `3 passed` archive_uniform_io; `5 passed` archive_tail_provenance; `12 passed` cli_golden; 0 failures anywhere)
- `cargo clippy -p gravlax --bin aie --tests -- -D warnings`: clean
- `git diff --check`: clean; only touched files reformatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012JvfZS2vsTMwoqC1Egn6kA