### PR TITLE
Prepare Gravlax v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,16 @@
 
 This file records user-visible changes in each Gravlax release.
 
-## Unreleased
+## [0.2.3] - 2026-09-11
+
+Existing `.aie` archives, `.aic` annotations, and `.aicollection` indexes remain
+usable without migration; no format changes. This release adds optional
+junction-seeded and one-pass ingest alignment with recorded provenance, cuts
+the memory and time of cohort-wide `collection find-events` by roughly 4x and
+10x on an eight-archive benchmark, adds GQ result metadata and explain tags,
+lets demo capsules ship a prebuilt collection, and expands the documentation.
+
+### Ingest and provenance
 
 - Add optional junction-seeded and one-pass ingest alignment. `aie ingest
   junctions` writes a STAR `--sjdbFileChrStartEnd` seed file from a GTF or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,13 +21,11 @@ lets demo capsules ship a prebuilt collection, and expands the documentation.
   matching `--junction-discovery`, `--junction-catalogue`, and
   `--alignment-annotation` declarations, so the seed and discovery mode are
   recorded in archive provenance. No archive-format change.
-
 - `aie ingest recipe` now derives the default `--sjdbOverhang` from
   `--chemistry` instead of using a fixed 100: 90 for 10x 3' v3/v3.1 (91 bp cDNA
   reads) and 97 for 10x 3' v2 (98 bp cDNA reads), following STAR's read length
   minus one rule. `--sjdb-overhang <N>` still overrides it, and the flag is
   still emitted only with `--junction-seed`.
-
 - `aie inspect-archive` now shows alignment provenance in its human-readable
   output. The legacy text summary and the `--format text`/`--format tsv`
   reports list the provenance status, junction discovery mode, junction
@@ -37,58 +35,7 @@ lets demo capsules ship a prebuilt collection, and expands the documentation.
   The `--json` output is unchanged; `--format json` gains the same rows as an
   `alignment_provenance` table. No archive-format change.
 
-### Documentation
-
-- Add "When to use geometry fidelity" guidance to the `ingest-archive` and
-  format pages, with measured PBMC 5k archive-size and deviation numbers for
-  the default and `--geometry-fidelity` encodings.
-- Lead the README and installation page with `conda install -c bioconda
-  gravlax`, and describe the GitHub release binaries and installers alongside
-  the from-source build.
-- Document `Client.replay(..., gene_full=True, solo_strand=...)` and mention
-  `gq_run` where the Python client is introduced.
-
-### GQ
-
-**Result metadata.** `gq run` summaries document the denominators that the result
-table cannot carry, because `tally` emits observed combinations only: the evidence
-`unit`, `state_fields` (the `<name>_state` columns in declared order), and per-group
-`population_units` and `source_scope_units` alongside the existing totals. These are
-additive within `gravlax.gq.result.v1`; existing readers, including the Python client,
-are unaffected.
-
-**Exported function signatures.** Missing annotations on an `export fn` are now
-reported with the function name and the byte offset of the parameter or return arrow
-they belong to, rather than one message for the whole declaration. Bare scientific
-types on an exported signature are reported the same way. Explicit types were already
-required on `export fn`; inference remains available to file-local `fn`.
-
-**Explain: per-predicate effect tags.** `gq explain` adds `predicate_effect_tags`,
-one entry per predicate occurrence giving its stage, output column, byte offset, and
-whether it is chain-invariant (decided exactly by either retained representative) or
-extent-sensitive (dependent on geometry the chain quotient does not retain). The
-existing `semantics.predicate_effects` rule summary is unchanged.
-
-### Demonstration capsules
-
-- A demo capsule may now publish a prebuilt, rooted `.aicollection` with shape
-  routes plus a `--locations` manifest keyed by the committed source identities.
-  `packaging/build_demo_capsule.py` builds it from a public-neutral staging root
-  (`--collection-staging-root`, defaulting to the system temporary directory) and
-  records its `aicollection-directory-root-v1` root; `finalize_demo_capsule.py`
-  binds both files to the immutable data-release URLs; `verify_demo_capsule.py`
-  verifies that root through the published location manifest and runs both
-  collection stories against the relocated bytes without rebuilding.
-- `demo-manifest.schema.json` gains an optional top-level `collection` object.
-  Existing `demo-data-v1` manifests, which declare none, remain valid.
-- Notebooks 02 and 03 use a published collection when the manifest declares one
-  and otherwise rebuild it locally as before. The published path is fail-closed:
-  hash-pinned bytes, no fallback address, the declared collection must commit
-  exactly that story's archives and build options, and the location manifest must
-  resolve exactly the archives already verified by archive root. Notebook 01 is
-  unchanged.
-
-### `collection find-events` exact reduction
+### `collection find-events` performance and profiling
 
 Cohort-wide `collection find-events` reduces exact molecule evidence through a
 packed sorted-hit representation instead of hash maps keyed by
@@ -109,14 +56,61 @@ candidates, which the packed reducer cannot address; lower `--max-candidates`
 or strengthen the catalogue predicates. Events with more than three components
 are likewise rejected rather than silently dropping component counts.
 
-### `collection find-events` stage profile
-
 `collection find-events` now reports a per-stage wall-clock and peak-RSS
 profile. `data.summary.stage_seconds` and `data.summary.stage_peak_rss_bytes`
 record `load_catalogue`, `discover_candidates`, `route_candidates`,
 `exact_counting`, `terminal_tails`, `annotation_classification` and `output`;
 human output prints the same rows on stderr. Like `total_seconds`, the profile
 is sampled before the result tables are streamed. No scientific field changed.
+
+### GQ result metadata and diagnostics
+
+- **Result metadata.** `gq run` summaries document the denominators that the result
+  table cannot carry, because `tally` emits observed combinations only: the evidence
+  `unit`, `state_fields` (the `<name>_state` columns in declared order), and per-group
+  `population_units` and `source_scope_units` alongside the existing totals. These are
+  additive within `gravlax.gq.result.v1`; existing readers, including the Python client,
+  are unaffected.
+- **Exported function signatures.** Missing annotations on an `export fn` are now
+  reported with the function name and the byte offset of the parameter or return arrow
+  they belong to, rather than one message for the whole declaration. Bare scientific
+  types on an exported signature are reported the same way. Explicit types were already
+  required on `export fn`; inference remains available to file-local `fn`.
+- **Explain: per-predicate effect tags.** `gq explain` adds `predicate_effect_tags`,
+  one entry per predicate occurrence giving its stage, output column, byte offset, and
+  whether it is chain-invariant (decided exactly by either retained representative) or
+  extent-sensitive (dependent on geometry the chain quotient does not retain). The
+  existing `semantics.predicate_effects` rule summary is unchanged.
+
+### Demonstration capsules
+
+- A demo capsule may now publish a prebuilt, rooted `.aicollection` with shape
+  routes plus a `--locations` manifest keyed by the committed source identities.
+  `packaging/build_demo_capsule.py` builds it from a public-neutral staging root
+  (`--collection-staging-root`, defaulting to the system temporary directory) and
+  records its `aicollection-directory-root-v1` root; `finalize_demo_capsule.py`
+  binds both files to the immutable data-release URLs; `verify_demo_capsule.py`
+  verifies that root through the published location manifest and runs both
+  collection stories against the relocated bytes without rebuilding.
+- `demo-manifest.schema.json` gains an optional top-level `collection` object.
+  Existing `demo-data-v1` manifests, which declare none, remain valid.
+- Notebooks 02 and 03 use a published collection when the manifest declares one
+  and otherwise rebuild it locally as before. The published path is fail-closed:
+  hash-pinned bytes, no fallback address, the declared collection must commit
+  exactly that story's archives and build options, and the location manifest must
+  resolve exactly the archives already verified by archive root. Notebook 01 is
+  unchanged.
+
+### Documentation
+
+- Add "When to use geometry fidelity" guidance to the `ingest-archive` and
+  format pages, with measured PBMC 5k archive-size and deviation numbers for
+  the default and `--geometry-fidelity` encodings.
+- Lead the README and installation page with `conda install -c bioconda
+  gravlax`, and describe the GitHub release binaries and installers alongside
+  the from-source build.
+- Document `Client.replay(..., gene_full=True, solo_strand=...)` and mention
+  `gq_run` where the Python client is introduced.
 
 ## [0.2.2] - 2026-09-10
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,7 +361,7 @@ dependencies = [
 
 [[package]]
 name = "eval"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "gravlax-evidence-io",
@@ -459,7 +459,7 @@ dependencies = [
 
 [[package]]
 name = "gravlax"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "blake3",
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "gravlax-anno"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "blake3",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "gravlax-evidence-io"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "blake3",
@@ -515,7 +515,7 @@ dependencies = [
 
 [[package]]
 name = "gravlax-ingest"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "gravlax-evidence-io",
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "gravlax-output"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "libc",
  "serde",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "replay"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "gravlax-evidence-io",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 rust-version = "1.89"
 authors = ["Gravlax contributors"]
@@ -41,10 +41,10 @@ noodles-sam = "0.90"
 noodles-bgzf = "0.51"
 noodles-core = "0.20"
 noodles-gtf = "0.57"
-evidence-io = { package = "gravlax-evidence-io", version = "=0.2.2", path = "crates/evidence-io" }
-anno = { package = "gravlax-anno", version = "=0.2.2", path = "crates/anno" }
-ingest = { package = "gravlax-ingest", version = "=0.2.2", path = "crates/ingest" }
-gravlax-output = { version = "=0.2.2", path = "crates/gravlax-output" }
+evidence-io = { package = "gravlax-evidence-io", version = "=0.2.3", path = "crates/evidence-io" }
+anno = { package = "gravlax-anno", version = "=0.2.3", path = "crates/anno" }
+ingest = { package = "gravlax-ingest", version = "=0.2.3", path = "crates/ingest" }
+gravlax-output = { version = "=0.2.3", path = "crates/gravlax-output" }
 
 # cargo-dist owns the native archives and installers. Release-specific checks,
 # Python artifacts, the vendored source archive, and crates.io publication are

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gravlax-docs",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gravlax-docs",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "dependencies": {
         "@astrojs/starlight": "0.41.11",
         "astro": "7.2.10",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gravlax-docs",
   "type": "module",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "scripts": {
     "dev": "astro dev",

--- a/packaging/conda/local/meta.yaml
+++ b/packaging/conda/local/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = environ.get("GRAVLAX_VERSION", "0.2.2") %}
+{% set version = environ.get("GRAVLAX_VERSION", "0.2.3") %}
 
 package:
   name: gravlax

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gravlax-client"
-version = "0.2.2"
+version = "0.2.3"
 description = "Dependency-light Python client for the Gravlax aie command-line interface"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/python/src/gravlax/__init__.py
+++ b/python/src/gravlax/__init__.py
@@ -158,4 +158,4 @@ __all__ = [
     "read_mex",
 ]
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"


### PR DESCRIPTION
Prepare Gravlax v0.2.3. Existing `.aie` archives, `.aic` annotations, and `.aicollection` indexes remain usable without migration; no format changes. This release adds optional junction-seeded and one-pass ingest alignment with recorded provenance, cuts the memory and time of cohort-wide `collection find-events` by roughly 4x and 10x on an eight-archive benchmark, adds GQ result metadata and explain tags, lets demo capsules ship a prebuilt collection, and expands the documentation.

## Changes

- Date and tidy the 0.2.3 changelog section: one `collection find-events` subsection instead of two, a descriptive GQ heading with the same bullet form as its siblings, and the documentation subsection last. No wording changes.
- Coordinate the Rust workspace, lockfile, Python package and runtime, documentation package and lockfile, and the local conda recipe at **0.2.3** via `./scripts/bump-and-publish 0.2.3 --prepare`.

## Validation

`./scripts/bump-and-publish 0.2.3 --dry-run --check-history` and `./scripts/bump-and-publish 0.2.3 --prepare` both completed on the repository-pinned Rust 1.89.0 toolchain with Node.js 22.22.3 and Python 3.12:

- 472 Rust tests passed across the workspace with `--all-targets --locked`; 3 pre-existing tests remain ignored; 0 failures.
- 96 Python client tests and 48 packaging tests passed.
- Version consistency, release-notes, publishable package-graph, public-source tracked-tree and full `HEAD`-ancestry checks passed.
- `cargo publish --dry-run --locked` succeeded for `gravlax-evidence-io`, `gravlax-output`, `gravlax-anno`, `gravlax-ingest`, and `gravlax`.
- The documentation site built successfully: 32 pages.

Release binary built locally from this branch with `cargo build --release --locked --package gravlax --bin aie`:

```
$ aie --version
aie 0.2.3

SHA-256 (target/release/aie)
baf5a1b67d44efc969083ae6f6f40751a3bf8c113b31fa96c4d5d192fbcb9f57
```

This local binary is a build check only; the published artifacts are the ones cargo-dist builds from the tag.

## Tagging

`--prepare` created only the local annotated tag `v0.2.3`; nothing was pushed or published. As with 0.2.2, this PR carries the version bump, and the `v0.2.3` tag is placed on the merge commit from a clean, up-to-date `main` after the required native portability checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012JvfZS2vsTMwoqC1Egn6kA
